### PR TITLE
Add roadmap and sync planning references

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ npm run preview          # Serves the production bundle with asset headers and C
 - **Security-first workflows** — mkcert-driven HTTPS, CSP enforcement, Workers rate limiting, and Vale-driven content linting all run by default to satisfy regulated-industry audits.
 - **Extensive runbooks** — Architecture decisions, incident response guides, and brand governance live under `/docs` with direct callouts from the README so new hires never chase tribal knowledge.
 
+> **Planning sync:** Track shipped increments and upcoming automation-first work in the [ROADMAP](ROADMAP.md) so every team references the same delivery narrative as they prioritize features.
+
 > **Where to dive deeper:** Start with the [Architecture Decision Ledger](docs/architecture/DECISIONS.md), inspect the [system context diagram](docs/architecture/system-context.svg), then review the [brand style guide](docs/brand/STYLEGUIDE.md) before editing UI.
 
 ## Contributing
@@ -84,6 +86,7 @@ npm run preview          # Serves the production bundle with asset headers and C
 3. Run `npm run test` and `npm run build` before opening a PR so CI remains a confirmation step, not a debugging session.
 4. Document changes in `CHANGELOG.md` and the relevant `/docs` section; our investors and compliance teams rely on those artifacts for review cycles.
 5. Use the [Quick Start](#quick-start) commands whenever refreshing dependencies—the automation scripts regenerate assets, diagrams, and search indexes automatically.
+6. Reconcile proposals with the [ROADMAP](ROADMAP.md) before opening a PR so roadmap, docs, and implementation remain fully aligned.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,69 @@
+# Apotheon.ai Delivery Roadmap
+
+> **Operating principle:** Ship static-first, automation-enforced increments that keep the marketing and documentation hub pre-production ready at all times. Every line item below traces back to a scriptable workflow so manual effort never becomes a dependency.
+
+## Shipped Releases
+
+### v1.0 — Static-First Investor Hub (Shipped)
+
+- ✅ Astro foundation with Tailwind + Radix design system, pagefind search, and workers hardening deployed to Cloudflare Pages.
+- ✅ Content automation covers hero media, OG assets, and whitepaper stubs to avoid asset drift between releases.
+- 🔁 Observability, SEO, and security checks wired into the default CI lint job so teams inherit enterprise baselines.
+- **Automation notes:**
+  - [scripts/content/ensure-homepage-hero-media.ts](scripts/content/ensure-homepage-hero-media.ts) backfills hero imagery before every build.
+  - [scripts/content/ensure-og-assets.ts](scripts/content/ensure-og-assets.ts) guarantees OG/Twitter cards stay in sync with Markdown copy.
+  - [scripts/security/mkcert-localhost.sh](scripts/security/mkcert-localhost.sh) supplies local TLS to rehearse CSP policies before shipping.
+
+## Near-Term Milestones
+
+### v1.1 — Multi-language Support & Localization Ops (Next)
+
+- Expand Astro i18next configuration to deliver localized navigation, metadata, and CTA flows while preserving static prerendering.
+- Establish translation memory and glossary governance to keep messaging consistent across regulated industries.
+- Integrate Vale localization styles to block untranslated content from merging.
+- **Automation notes:**
+  - [astro-i18next.config.mjs](astro-i18next.config.mjs) stores locale routing, fallback, and namespace conventions.
+  - [scripts/content/run-vale.mjs](scripts/content/run-vale.mjs) executes Vale with localization-aware styles in CI and pre-commit.
+  - [scripts/content/ensure-cms-config.mjs](scripts/content/ensure-cms-config.mjs) seeds multilingual CMS scaffolding so editors get deterministic frontmatter requirements.
+
+### v1.2 — Personalization & Recommendation Enhancements
+
+- Extend the static Pagefind index with investor personas and integrate recommendation data into hero modules without runtime penalties.
+- Wire investor/industry taxonomy to workers for gated download personalization and investor brief prioritization.
+- Harden metrics to confirm improved engagement via synthetic monitoring and Lighthouse budgets.
+- **Automation notes:**
+  - [scripts/content/build-blog-recommendations.mjs](scripts/content/build-blog-recommendations.mjs) regenerates recommendation vectors during `npm run build`.
+  - [scripts/search](scripts/search) utilities normalize Pagefind indexing for new taxonomies.
+  - [scripts/tests](scripts/tests) suites keep Playwright/Ladle smoke coverage current as personalization variants increase.
+
+### v1.3 — Compliance-Grade Lead Handling
+
+- Deploy the Cloudflare Worker contact pipeline with KV-backed rate limiting, Turnstile validation, and D1 audit storage.
+- Provide investor dashboards summarizing signed download activity and compliance attestations.
+- Fold incident response hooks into ops runbooks with automated dry runs.
+- **Automation notes:**
+  - [workers/contact](workers/contact) Worker handlers encapsulate validation, storage, and webhook emission.
+  - [scripts/ops](scripts/ops) contains backup and verification routines, including `ops:backup:dry-run` for D1/R2 exports.
+  - [scripts/security](scripts/security) provides abuse detection and secret rotation helpers used by the worker deployment flow.
+
+## Longer-Term Initiatives
+
+### AI-Augmented Content Governance
+
+- Author review bots that enrich Markdown with compliance footnotes and investor risk scoring before publication.
+- Surface tone, reading level, and compliance gaps inside PR comments to keep content audit-ready.
+- **Automation notes:** Integrate with [scripts/content/shared](scripts/content/shared) utilities to lint Markdown frontmatter and queue Vale profiles per persona.
+
+### Global Platform Observability
+
+- Expand synthetic monitoring to cover SLA/SLO dashboards, RUM ingestion, and Lighthouse regression tests per locale.
+- Automate on-call previews with screenshot diffs and accessibility traces appended to every release.
+- **Automation notes:** [scripts/perf](scripts/perf) and [scripts/seo](scripts/seo) directories host lighthouse, CWV, and schema validators ready for CI orchestration.
+
+### Enterprise Knowledge Delivery
+
+- Publish API documentation and knowledge base updates through a single MDX pipeline synced with worker APIs and signed assets.
+- Offer investors auto-generated briefings that aggregate blog, whitepaper, and product insights from the same static bundle.
+- **Automation notes:** [scripts/content/generate-whitepapers.ts](scripts/content/generate-whitepapers.ts) and [scripts/content/ensure-whitepapers.ts](scripts/content/ensure-whitepapers.ts) keep gated assets synchronized with marketing pages.
+
+> **Keep shipping:** Re-run `npm run lint` + `npm run build` before every release to exercise the full automation lattice. Anything that cannot be scripted gets logged as technical debt in `docs/workplan/EPICS_AND_WORK_ITEMS.md`.

--- a/docs/workplan/EPICS_AND_WORK_ITEMS.md
+++ b/docs/workplan/EPICS_AND_WORK_ITEMS.md
@@ -12,7 +12,7 @@ docs/workplan/EPICS_AND_WORK_ITEMS.md
 > **Observability:** **GlitchTip** (OSS Sentry‑compatible) or **Sentry self‑host**, **Uptime‑Kuma** (OSS).
 > **Note:** All third‑party services are free‑tier or OSS; where SaaS is chosen (e.g., Cloudflare), an OSS/self‑host alternative is listed in the Epic.
 
-> **Orientation cue:** Anchor discussions to the [README hero pledge](../../README.md#apotheonai-web-platform) and [Quick Start automation flow](../../README.md#quick-start) so epics map cleanly to the documented delivery posture.
+> **Orientation cue:** Anchor discussions to the [README hero pledge](../../README.md#apotheonai-web-platform), [Quick Start automation flow](../../README.md#quick-start), and cross-check against the [ROADMAP](../../ROADMAP.md) so epics, roadmap increments, and delivery posture stay synchronized.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a roadmap document cataloging shipped releases, upcoming milestones, and long-term initiatives with automation references
- link the roadmap from the README and workplan so contributors and planners share the same delivery context

## Testing
- npm run lint *(fails: existing import/no-unresolved and @typescript-eslint/no-unsafe-* errors in whitepaper automation scripts referencing pdf-lib assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d846019538832e82e114b5ace49b97