### PR TITLE
feat: launch research marketing hub and navigation updates

### DIFF
--- a/docs/content/CALENDAR.md
+++ b/docs/content/CALENDAR.md
@@ -36,6 +36,21 @@ and campaign assets that go live each week.
    planning so marketing, RevOps, and engineering stay aligned on which features
    and content will be under test.
 
+### Research hub release process
+
+1. Draft or update the MDX narrative in `src/content/marketing/research.mdx` with
+   `[//]: #` workflow annotations. Ship the change through Pull Request so
+   Pagefind reindexes automatically during `npm run build`.
+2. Sync cohort milestones and sandbox availability windows in this calendar so
+   growth, RevOps, and academic partners operate against the same timeline.
+3. Refresh supporting assets:
+   - Run `npm run ensure:whitepapers` if download descriptions change.
+   - Re-render diagrams under `public/static/diagrams/research/` when the FEDGEN
+     or Trace Synthesis topology evolves.
+4. Confirm the `/research/` route renders as expected by running `npm run lint`,
+   `npm run typecheck`, and `npm run build`. Capture updates in the PR summary so
+   reviewers know the automation suite executed.
+
 ## Onboarding Checklist
 
 - Read `docs/dev/EDITORIAL.md` for the full publishing workflow.

--- a/public/data/blog/recommendations.json
+++ b/public/data/blog/recommendations.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-28T14:33:59.679Z",
+  "generatedAt": "2025-10-04T19:06:54.351Z",
   "metadata": {
     "decayHalfLifeDays": 14,
     "eventWeights": {
@@ -45,27 +45,27 @@
   "topArticles": [
     {
       "slug": "continuous-learning",
-      "score": 0.000005627726628796055,
+      "score": 0.0000041423330690223495,
       "breakdown": {
         "article_view": 0,
-        "interaction": 0.000002945576065284744,
-        "conversion": 0.0000026821505635113113
+        "interaction": 0.000002168114755275528,
+        "conversion": 0.000001974218313746822
       }
     },
     {
       "slug": "welcome",
-      "score": 0.00000267416797254848,
+      "score": 0.000001968342664003528,
       "breakdown": {
-        "article_view": 0.00000267416797254848,
+        "article_view": 0.000001968342664003528,
         "interaction": 0,
         "conversion": 0
       }
     },
     {
       "slug": "integration-governance",
-      "score": 0.0000016926710074607051,
+      "score": 0.000001245903994928029,
       "breakdown": {
-        "article_view": 0.0000016926710074607051,
+        "article_view": 0.000001245903994928029,
         "interaction": 0,
         "conversion": 0
       }

--- a/public/static/diagrams/research/fedgen-trace-synthesis.svg
+++ b/public/static/diagrams/research/fedgen-trace-synthesis.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">FEDGEN and Trace Synthesis integration data flow</title>
+  <desc id="desc">Diagram showing how academic partners submit datasets into the FEDGEN broker which synchronizes with the Trace Synthesis pipeline before activating governed sandboxes.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+    <style>
+      .panel { fill: rgba(15,23,42,0.7); stroke: #38bdf8; stroke-width: 2; rx: 16; ry: 16; }
+      .label { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; fill: #e2e8f0; font-size: 20px; font-weight: 600; }
+      .body { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; fill: #cbd5f5; font-size: 16px; }
+      .arrow { stroke: #38bdf8; stroke-width: 2; marker-end: url(#arrowhead); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#38bdf8" />
+    </marker>
+  </defs>
+  <rect x="0" y="0" width="960" height="540" fill="url(#bg)" />
+  <rect class="panel" x="60" y="96" width="240" height="180" />
+  <text class="label" x="180" y="140" text-anchor="middle">Academic Nodes</text>
+  <text class="body" x="180" y="170" text-anchor="middle">University labs</text>
+  <text class="body" x="180" y="200" text-anchor="middle">Joint review boards</text>
+  <text class="body" x="180" y="230" text-anchor="middle">Encrypted corpora uploads</text>
+
+  <rect class="panel" x="360" y="60" width="240" height="180" />
+  <text class="label" x="480" y="104" text-anchor="middle">FEDGEN Broker</text>
+  <text class="body" x="480" y="134" text-anchor="middle">Policy validation</text>
+  <text class="body" x="480" y="164" text-anchor="middle">Consent lineage ledger</text>
+  <text class="body" x="480" y="194" text-anchor="middle">Zero-copy dataset escrow</text>
+
+  <rect class="panel" x="360" y="300" width="240" height="180" />
+  <text class="label" x="480" y="344" text-anchor="middle">Trace Synthesis</text>
+  <text class="body" x="480" y="374" text-anchor="middle">Feature distillation</text>
+  <text class="body" x="480" y="404" text-anchor="middle">Bias instrumentation</text>
+  <text class="body" x="480" y="434" text-anchor="middle">Regulated replay trails</text>
+
+  <rect class="panel" x="660" y="180" width="240" height="180" />
+  <text class="label" x="780" y="224" text-anchor="middle">Governed Sandboxes</text>
+  <text class="body" x="780" y="254" text-anchor="middle">Nova research tenants</text>
+  <text class="body" x="780" y="284" text-anchor="middle">Automated export controls</text>
+  <text class="body" x="780" y="314" text-anchor="middle">Signed telemetry bundles</text>
+
+  <line class="arrow" x1="300" y1="186" x2="360" y2="150" />
+  <line class="arrow" x1="300" y1="186" x2="360" y2="390" />
+  <line class="arrow" x1="600" y1="150" x2="660" y2="240" />
+  <line class="arrow" x1="600" y1="390" x2="660" y2="240" />
+</svg>

--- a/src/components/homepage/ResearchBanner.astro
+++ b/src/components/homepage/ResearchBanner.astro
@@ -1,0 +1,54 @@
+---
+import { formatContactReachability, injectOperationalHoursCopy } from './ctaContactNote';
+
+import type { HomepageResearchBanner } from '@content/homepage';
+
+interface Props {
+  banner: HomepageResearchBanner;
+}
+
+const { banner } = Astro.props as Props;
+const descriptionId = 'research-banner-description';
+const contactId = 'research-banner-contact';
+const secondaryCopy = injectOperationalHoursCopy(banner.secondaryText);
+const contactNote = formatContactReachability('Research partnerships');
+---
+
+<section
+  aria-labelledby="research-banner-heading"
+  aria-describedby={`${descriptionId} ${contactId}`}
+  class="overflow-hidden rounded-3xl border border-emerald-500/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 shadow-xl ring-1 ring-emerald-500/20"
+  data-analytics-region="homepage-research-banner"
+>
+  <div class="space-y-6">
+    <header class="space-y-3">
+      <h2 id="research-banner-heading" class="text-3xl font-semibold text-white md:text-4xl">
+        {banner.heading}
+      </h2>
+      <p id={descriptionId} class="text-base text-slate-300 md:text-lg">
+        {banner.body}
+      </p>
+      {
+        secondaryCopy ? (
+          <p class="text-sm text-emerald-300/80 md:text-base">{secondaryCopy}</p>
+        ) : null
+      }
+    </header>
+
+    <p id={contactId} class="sr-only">
+      {contactNote}
+    </p>
+
+    <a
+      class="inline-flex items-center justify-center gap-2 rounded-full border border-emerald-400/70 bg-emerald-400 px-6 py-3 text-sm font-semibold tracking-wide text-slate-950 uppercase transition hover:bg-emerald-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200"
+      data-analytics-id="homepage-research-banner-cta"
+      data-testid="research-banner-cta"
+      href={banner.cta.href}
+      aria-label={banner.cta.ariaLabel}
+      aria-describedby={`${descriptionId} ${contactId}`}
+    >
+      {banner.cta.label}
+      <span aria-hidden class="text-lg"> → </span>
+    </a>
+  </div>
+</section>

--- a/src/components/homepage/ResearchBannerSection.tsx
+++ b/src/components/homepage/ResearchBannerSection.tsx
@@ -1,0 +1,60 @@
+import React, { type FC } from 'react';
+
+import { formatContactReachability, injectOperationalHoursCopy } from './ctaContactNote';
+
+import type { HomepageResearchBanner } from '@content/homepage';
+
+export interface ResearchBannerSectionProps {
+  banner: HomepageResearchBanner;
+}
+
+const ResearchBannerSection: FC<ResearchBannerSectionProps> = ({ banner }) => {
+  const descriptionId = React.useId();
+  const contactId = React.useId();
+  const headingId = React.useId();
+  const secondaryCopy = injectOperationalHoursCopy(banner.secondaryText);
+  const contactNote = formatContactReachability('Research partnerships');
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      aria-describedby={`${descriptionId} ${contactId}`}
+      className="overflow-hidden rounded-3xl border border-emerald-500/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 shadow-xl ring-1 ring-emerald-500/20"
+      data-analytics-region="homepage-research-banner"
+    >
+      <div className="space-y-6">
+        <header className="space-y-3">
+          <h2 id={headingId} className="text-3xl font-semibold text-white md:text-4xl">
+            {banner.heading}
+          </h2>
+          <p id={descriptionId} className="text-base text-slate-300 md:text-lg">
+            {banner.body}
+          </p>
+          {secondaryCopy ? (
+            <p className="text-sm text-emerald-300/80 md:text-base">{secondaryCopy}</p>
+          ) : null}
+        </header>
+
+        <p id={contactId} className="sr-only">
+          {contactNote}
+        </p>
+
+        <a
+          className="inline-flex items-center justify-center gap-2 rounded-full border border-emerald-400/70 bg-emerald-400 px-6 py-3 text-sm font-semibold tracking-wide text-slate-950 uppercase transition hover:bg-emerald-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200"
+          data-analytics-id="homepage-research-banner-cta"
+          data-testid="research-banner-cta"
+          href={banner.cta.href}
+          aria-label={banner.cta.ariaLabel}
+          aria-describedby={`${descriptionId} ${contactId}`}
+        >
+          {banner.cta.label}
+          <span aria-hidden className="text-lg">
+            →
+          </span>
+        </a>
+      </div>
+    </section>
+  );
+};
+
+export default ResearchBannerSection;

--- a/src/components/homepage/__tests__/ResearchBanner.test.tsx
+++ b/src/components/homepage/__tests__/ResearchBanner.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { formatContactReachability, injectOperationalHoursCopy } from '../ctaContactNote';
+import ResearchBannerSection from '../ResearchBannerSection';
+
+const researchBanner = {
+  heading: 'Research partnerships & sandboxes',
+  body: 'Coordinate academic cohorts, FEDGEN integrations, and Trace Synthesis sandboxes without bespoke intake workflows.',
+  secondaryText: 'Research requests route to dedicated RevOps analysts during %officeHours%.',
+  cta: {
+    label: 'Explore research hub',
+    href: '/research',
+    ariaLabel: 'Navigate to the Apotheon.ai research and academic partnerships hub',
+  },
+};
+
+const expectedEmail = 'hello@apotheon.ai';
+const expectedPhone = '+1-206-555-0188';
+
+describe('Research CTA banner', () => {
+  it('links aria-describedby text to both the body copy and contact note', async () => {
+    render(<ResearchBannerSection banner={researchBanner} />);
+
+    const cta = screen.getByTestId('research-banner-cta');
+    const describedBy = cta.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    const describedIds = describedBy?.split(' ') ?? [];
+    describedIds.forEach((id: string) => {
+      const node = document.getElementById(id);
+      expect(node).not.toBeNull();
+    });
+  });
+
+  it('mirrors contact metadata so assistive tech announces outreach details', async () => {
+    const contactNote = formatContactReachability('Research partnerships');
+    const secondaryCopy = injectOperationalHoursCopy(researchBanner.secondaryText);
+
+    render(<ResearchBannerSection banner={researchBanner} />);
+
+    expect(screen.getAllByText(researchBanner.heading).length).toBeGreaterThan(0);
+    if (secondaryCopy) {
+      expect(screen.getAllByText(secondaryCopy).length).toBeGreaterThan(0);
+    }
+    expect(screen.getAllByText(contactNote).length).toBeGreaterThan(0);
+
+    expect(contactNote).toContain(expectedEmail);
+    expect(contactNote).toContain(expectedPhone);
+  });
+});

--- a/src/components/islands/RadixNavigationMenu.tsx
+++ b/src/components/islands/RadixNavigationMenu.tsx
@@ -206,6 +206,46 @@ export const navigationMenuGroups: ReadonlyArray<NavigationMenuGroup> = [
   },
   {
     /**
+     * Research navigation surfaces the academic partnership hub alongside Trace Synthesis
+     * enablement resources. Aligning the data structure with other groups means navigation
+     * validators and Pagefind indexing automatically recognize the /research route whenever
+     * marketing ships new MDX updates.
+     */
+    id: 'research',
+    label: 'Research',
+    labelKey: 'navigation.groups.research.label',
+    description:
+      'Academic partnerships, Trace Synthesis integrations, and sandbox provisioning guidance.',
+    descriptionKey: 'navigation.groups.research.description',
+    links: [
+      {
+        id: 'research-hub',
+        label: 'Research partnerships hub',
+        labelKey: 'navigation.groups.research.links.hub.label',
+        href: '/research',
+        description: 'Program overview, FEDGEN workflows, and publication guidance.',
+        descriptionKey: 'navigation.groups.research.links.hub.description',
+      },
+      {
+        id: 'research-nova',
+        label: 'Nova research tenants',
+        labelKey: 'navigation.groups.research.links.nova.label',
+        href: '/solutions/nova',
+        description: 'Isolation controls and export governance for academic workloads.',
+        descriptionKey: 'navigation.groups.research.links.nova.description',
+      },
+      {
+        id: 'research-whitepapers',
+        label: 'Sovereign AI Assurance',
+        labelKey: 'navigation.groups.research.links.whitepapers.label',
+        href: '/about/white-papers',
+        description: 'Download attestation playbooks and Trace Synthesis integration briefs.',
+        descriptionKey: 'navigation.groups.research.links.whitepapers.description',
+      },
+    ],
+  },
+  {
+    /**
      * Incident response guides stay isolated in their own menu bucket so security teams can hotlink
      * the exact playbook they need during incidents without parsing the broader handbook catalog.
      */

--- a/src/components/navigation/navigationData.ts
+++ b/src/components/navigation/navigationData.ts
@@ -262,6 +262,11 @@ export async function getFooterColumns(t?: Translator): Promise<ReadonlyArray<Fo
       titleKey: 'footer.columns.industries.title',
       fallbackTitle: 'Industries',
     },
+    {
+      sourceId: 'research',
+      titleKey: 'footer.columns.research.title',
+      fallbackTitle: 'Research',
+    },
     { sourceId: 'company', titleKey: 'footer.columns.company.title', fallbackTitle: 'Company' },
   ];
 

--- a/src/content/docs-manifest/manifest.json
+++ b/src/content/docs-manifest/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-30T17:00:37.663Z",
+  "generatedAt": "2025-10-04T19:07:55.881Z",
   "source": "file:///workspace/apotheon.ai/docs",
   "entries": [
     {
@@ -9,7 +9,7 @@
       "categoryLabel": "AI Playbooks",
       "slug": "ai-instructions",
       "sourcePath": "ai-instructions.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Architecture Decision Ledger",
@@ -18,7 +18,7 @@
       "categoryLabel": "Architecture",
       "slug": "architecture/decisions",
       "sourcePath": "architecture/DECISIONS.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Apotheon Brand & Experience Style Guide",
@@ -27,7 +27,7 @@
       "categoryLabel": "Brand",
       "slug": "brand/styleguide",
       "sourcePath": "brand/STYLEGUIDE.md",
-      "sourceLastModified": "2025-09-30T15:59:37.715Z"
+      "sourceLastModified": "2025-10-04T18:30:39.439Z"
     },
     {
       "title": "Blog Editorial Playbook",
@@ -36,7 +36,7 @@
       "categoryLabel": "Content Strategy",
       "slug": "content/blog-editorial",
       "sourcePath": "content/BLOG_EDITORIAL.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Editorial and Experiment Calendar",
@@ -45,7 +45,7 @@
       "categoryLabel": "Content Strategy",
       "slug": "content/calendar",
       "sourcePath": "content/CALENDAR.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T18:39:00.494Z"
     },
     {
       "title": "CMS & Lead Management Playbook",
@@ -54,7 +54,7 @@
       "categoryLabel": "Content Strategy",
       "slug": "content/cms",
       "sourcePath": "content/CMS.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Marketing Information Architecture",
@@ -63,7 +63,7 @@
       "categoryLabel": "Content Strategy",
       "slug": "content/information-architecture",
       "sourcePath": "content/INFORMATION_ARCHITECTURE.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Accessibility Operations Playbook",
@@ -72,7 +72,7 @@
       "categoryLabel": "Development",
       "slug": "dev/accessibility",
       "sourcePath": "dev/ACCESSIBILITY.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Blog Delivery Workflow",
@@ -81,7 +81,7 @@
       "categoryLabel": "Development",
       "slug": "dev/blog",
       "sourcePath": "dev/BLOG.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Blog Analytics Platform",
@@ -90,7 +90,7 @@
       "categoryLabel": "Development",
       "slug": "dev/blog-analytics",
       "sourcePath": "dev/BLOG-ANALYTICS.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Continuous Integration Pipeline",
@@ -99,7 +99,16 @@
       "categoryLabel": "Development",
       "slug": "dev/ci-cd",
       "sourcePath": "dev/CI_CD.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
+    },
+    {
+      "title": "Deployment & Edge Compression Playbook",
+      "description": "This playbook equips release managers with the exact steps required to translate our post-build compression manifest into Cloudflare (or equivalent CDN) rules. The manifest is the single source of truth for which static artefacts ship with Brotli and gzip variants, the digests we use for cache-busting, and the metadata the CDN needs in order to serve the optimal encoding automatically. Lean on the manifest so you never have to craft bespoke caching policies by hand—the pipeline already produces the data in a deterministic, audit-friendly shape.",
+      "category": "dev",
+      "categoryLabel": "Development",
+      "slug": "dev/deployment",
+      "sourcePath": "dev/DEPLOYMENT.md",
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Editorial Playbook",
@@ -108,7 +117,7 @@
       "categoryLabel": "Development",
       "slug": "dev/editorial",
       "sourcePath": "dev/EDITORIAL.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "History Timeline Editorial Playbook",
@@ -117,7 +126,7 @@
       "categoryLabel": "Development",
       "slug": "dev/history",
       "sourcePath": "dev/HISTORY.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Homepage Governance",
@@ -126,7 +135,7 @@
       "categoryLabel": "Development",
       "slug": "dev/homepage",
       "sourcePath": "dev/HOMEPAGE.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Internationalisation Operations",
@@ -135,7 +144,7 @@
       "categoryLabel": "Development",
       "slug": "dev/i18n",
       "sourcePath": "dev/I18N.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Industries Editorial Playbook",
@@ -144,7 +153,7 @@
       "categoryLabel": "Development",
       "slug": "dev/industries",
       "sourcePath": "dev/INDUSTRIES.md",
-      "sourceLastModified": "2025-09-30T15:59:37.715Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Navigation Delivery Contract",
@@ -153,16 +162,16 @@
       "categoryLabel": "Development",
       "slug": "dev/navigation",
       "sourcePath": "dev/NAVIGATION.md",
-      "sourceLastModified": "2025-09-30T15:59:37.715Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Performance & OpenGraph Automation",
-      "description": "This guide captures the automation that keeps our marketing surface fast, visually consistent, and regression friendly. Use it as a runbook when introducing new assets or reviewing pull requests that touch the rendering pipeline. For the Playwright workflow that enforces visual fidelity, see [End-to-end testing & visual baselines](./TESTING.md).",
+      "description": "This guide captures the automation that keeps our marketing surface fast, visually consistent, and regression friendly. Use it as a runbook when introducing new assets or reviewing pull requests that touch the rendering pipeline. For the Playwright workflow that enforces visual fidelity, see [End-to-end testing & visual baselines](./TESTING.md). Deployment engineers should pair these notes with the [Deployment & Edge Compression Playbook](./DEPLOYMENT.md) to translate build artefacts into CDN cache rules without manual guesswork.",
       "category": "dev",
       "categoryLabel": "Development",
       "slug": "dev/performance",
       "sourcePath": "dev/PERFORMANCE.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Privacy & Analytics Runbook",
@@ -171,7 +180,7 @@
       "categoryLabel": "Development",
       "slug": "dev/privacy",
       "sourcePath": "dev/PRIVACY.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Role Targeting Presets",
@@ -180,7 +189,7 @@
       "categoryLabel": "Development",
       "slug": "dev/role-targeting",
       "sourcePath": "dev/ROLE-TARGETING.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "SEO & SMO Operations Guide",
@@ -189,7 +198,7 @@
       "categoryLabel": "Development",
       "slug": "dev/seo",
       "sourcePath": "dev/SEO.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Solutions Content Schema & Workflow",
@@ -198,7 +207,7 @@
       "categoryLabel": "Development",
       "slug": "dev/solutions",
       "sourcePath": "dev/SOLUTIONS.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T18:30:39.439Z"
     },
     {
       "title": "End-to-end testing & visual baselines",
@@ -207,7 +216,7 @@
       "categoryLabel": "Development",
       "slug": "dev/testing",
       "sourcePath": "dev/TESTING.md",
-      "sourceLastModified": "2025-09-30T16:35:03.665Z"
+      "sourceLastModified": "2025-10-04T15:54:28.567Z"
     },
     {
       "title": "Whitepaper delivery pipeline",
@@ -216,7 +225,7 @@
       "categoryLabel": "Development",
       "slug": "dev/whitepapers",
       "sourcePath": "dev/WHITEPAPERS.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Contact submission workflow",
@@ -225,7 +234,7 @@
       "categoryLabel": "Development",
       "slug": "dev/workflows",
       "sourcePath": "dev/WORKFLOWS.md",
-      "sourceLastModified": "2025-09-30T15:59:37.715Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Managed Service Alternatives",
@@ -234,7 +243,7 @@
       "categoryLabel": "Infrastructure",
       "slug": "infra/alternatives",
       "sourcePath": "infra/ALTERNATIVES.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Hosting Playbook",
@@ -243,7 +252,7 @@
       "categoryLabel": "Infrastructure",
       "slug": "infra/hosting",
       "sourcePath": "infra/HOSTING.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Go-Live Readiness Checklist",
@@ -252,7 +261,25 @@
       "categoryLabel": "Launch Readiness",
       "slug": "launch/go-live-checklist",
       "sourcePath": "launch/GO-LIVE_CHECKLIST.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
+    },
+    {
+      "title": "FEDGEN Capital Oversight Briefing",
+      "description": "1. Author or update the MDX source under `src/content/whitepapers/` (e.g., `fedgen-operational-oversight.mdx`). 2. Run `npm run ensure:whitepapers` to regenerate PDFs and update `assets/whitepapers/managed-assets.json` with fresh checksums. 3. Execute `npm run test && npm run build` to rebuild automation reports and ensure CI parity before publishing. 4. Commit the regenerated manifest entries alongside any README or landing page copy updates so reviewers can trace metrics to source artifacts.",
+      "category": "research",
+      "categoryLabel": "Research",
+      "slug": "research/fedgen",
+      "sourcePath": "research/FEDGEN.md",
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
+    },
+    {
+      "title": "Trace Synthesis Research Dossier",
+      "description": "1. Capture orchestrated traces from BWCCUM lanes with PII scrubbed at the edge. 2. Themis evaluates compliance posture and annotates the dataset with jurisdictional gating metadata. 3. Mnemosyne packages approved aggregates for activation while Hermes exposes scenario sandboxes for RevOps and partner enablement.",
+      "category": "research",
+      "categoryLabel": "Research",
+      "slug": "research/trace-synthesis",
+      "sourcePath": "research/TRACE_SYNTHESIS.md",
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Self-Hosted Font Policy",
@@ -261,7 +288,7 @@
       "categoryLabel": "Security",
       "slug": "security/font-hosting",
       "sourcePath": "security/FONT_HOSTING.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Incident Response Framework",
@@ -270,7 +297,7 @@
       "categoryLabel": "Security",
       "slug": "security/incident-response",
       "sourcePath": "security/INCIDENT_RESPONSE.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Local HTTPS + CSP Validation Playbook",
@@ -279,7 +306,7 @@
       "categoryLabel": "Security",
       "slug": "security/local-https",
       "sourcePath": "security/LOCAL_HTTPS.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Contact Abuse Containment Runbook",
@@ -288,7 +315,7 @@
       "categoryLabel": "Security",
       "slug": "security/runbook-contact-abuse",
       "sourcePath": "security/RUNBOOK_CONTACT_ABUSE.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "CSP Violation Triage Runbook",
@@ -297,7 +324,7 @@
       "categoryLabel": "Security",
       "slug": "security/runbook-csp-triage",
       "sourcePath": "security/RUNBOOK_CSP_Triage.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Whitepaper R2 Incident Runbook",
@@ -306,7 +333,7 @@
       "categoryLabel": "Security",
       "slug": "security/runbook-r2-incident",
       "sourcePath": "security/RUNBOOK_R2_INCIDENT.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T15:54:28.571Z"
     },
     {
       "title": "Epics And Work Items",
@@ -315,7 +342,7 @@
       "categoryLabel": "Workplan",
       "slug": "workplan/epics-and-work-items",
       "sourcePath": "workplan/EPICS_AND_WORK_ITEMS.md",
-      "sourceLastModified": "2025-09-30T04:05:36.323Z"
+      "sourceLastModified": "2025-10-04T18:30:39.439Z"
     }
   ]
 }

--- a/src/content/docs/ai-instructions.mdx
+++ b/src/content/docs/ai-instructions.mdx
@@ -6,7 +6,7 @@ description: '**Purpose:** Enforce a unified rule-set for engineering,
   documenting, testing, releasing, and operating the public-facing Apotheon.ai
   web experience.'
 sourcePath: ai-instructions.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/architecture/decisions.mdx
+++ b/src/content/docs/architecture/decisions.mdx
@@ -7,7 +7,7 @@ description: This document captures the canonical architecture choices for the
   that was made, expected consequences, and references to operating guidance
   such as [`docs/ai-instructions.md`](../ai-instructions.md).
 sourcePath: architecture/DECISIONS.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/brand/styleguide.mdx
+++ b/src/content/docs/brand/styleguide.mdx
@@ -19,7 +19,7 @@ description: '- [Brand Design North Star](#brand-design-north-star) - [Homepage
   Engineers](#adoption-workflow-for-designers--engineers) - [Navigation
   Information Architecture](#navigation-information-architecture)'
 sourcePath: brand/STYLEGUIDE.md
-sourceLastModified: 2025-09-30T15:59:37.715Z
+sourceLastModified: 2025-10-04T18:30:39.439Z
 tags: []
 ---
 
@@ -79,6 +79,15 @@ The ensure script deterministically rebuilds `hero-base.png` and derivative form
 - **Accessibility sync:** Update `heroMedia.alt` in `src/content/homepage/landing.mdx` whenever the illustration focus changes. Alt copy is the canonical description for assistive tech and analytics heatmaps.
 
 ---
+
+## Platform Narrative System
+
+> **Why document this:** Homepage copy, investor decks, and solution landing pages now share the BWCCUM → Themis → Mnemosyne → Hermes → Morpheus progression introduced in the README “Platform Overview”. Locking the story to a fixed cadence keeps marketing claims, diligence packets, and product UI labels synchronized.
+
+- **Authoring contract:** Update the `modules` array inside `src/content/homepage/landing.mdx` (see inline comments) when sequencing changes. Always run `npm run ensure:whitepapers` before editing copy so downloadable asset slugs stay accurate, then refresh `npm run lint && npm run typecheck && npm run build` to rehydrate automation snapshots.
+- **Research integration:** FEDGEN and Trace Synthesis references must link to the Markdown dossiers under `docs/research/`. Those files track asset provenance and automation hooks—never hardcode external URLs in hero/module copy without recording the redirect contract there.
+- **BWCCUM ↔ Themis interplay:** Visual collateral should mirror the orchestrated DAG hand-off: BWCCUM executes compliance-aware workloads, Themis certifies and pauses lanes on failure, Mnemosyne syndicates consented outputs, while Hermes/Morpheus expose automation and telemetry. Reuse these beats across decks, PDFs, and product UI to maintain investor/regulator trust.
+- **Metrics refresh cadence:** Quarterly RevOps reviews update the metrics reported in the README table and landing modules. When new data lands, regenerate PDFs via `npm run ensure:whitepapers`, rerun `npm run test` to rebuild automation reports, and update both README + landing copy in the same pull request.
 
 ## Token Orchestration & Theme Controls
 
@@ -284,7 +293,7 @@ _Rationale:_ A system-first stack eliminates layout shift on initial render, whi
 - **Optimized exports:** Running the build script writes production-ready assets into `public/static/icons/brand/`. The SVGO config (`svgo.config.cjs`) enforces precision, viewBox preservation, and adds `role="img"`/`focusable="false"` for consistent runtime behavior.
 - **React wrappers:** When marketing or product teams need JSX access, enable the optional React generation (`--react`) to refresh `src/components/icons/`. Components expose a typed `title` prop so experiences can opt into decorative or labelled usage.
 
-Current brand marks include the five Apotheon pillars (Clio, Hermes, THEMIS, Morpheus, Mnemosyne) plus six industry glyphs (energy, finance, healthcare, manufacturing, public sector, transport). Keep additions within this directory so the automation stack can reason over them.
+Current brand marks include the six Apotheon pillars (BWC-CUM, Clio, Hermes, THEMIS, Morpheus, Mnemosyne) plus six industry glyphs (energy, finance, healthcare, manufacturing, public sector, transport). Keep additions within this directory so the automation stack can reason over them.
 
 ### Accessibility Expectations
 

--- a/src/content/docs/content/blog-editorial.mdx
+++ b/src/content/docs/content/blog-editorial.mdx
@@ -6,7 +6,7 @@ description: This guide translates the automated blog pipeline into a repeatable
   editorial workflow. Every entry in `src/content/blog/` ships with inline
   comments—treat this document as the narrative companion for deeper context.
 sourcePath: content/BLOG_EDITORIAL.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/content/calendar.mdx
+++ b/src/content/docs/content/calendar.mdx
@@ -8,7 +8,7 @@ description: Apotheon.ai ships content and experiments on a rolling four-week
   onboarding new contributors—the dates below anchor GrowthBook experiments to
   the release notes and campaign assets that go live each week.
 sourcePath: content/CALENDAR.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T18:39:00.494Z
 tags: []
 ---
 
@@ -47,6 +47,21 @@ and campaign assets that go live each week.
 3. Update this calendar when cadence shifts. Review the entry during quarterly
    planning so marketing, RevOps, and engineering stay aligned on which features
    and content will be under test.
+
+### Research hub release process
+
+1. Draft or update the MDX narrative in `src/content/marketing/research.mdx` with
+   `[//]: #` workflow annotations. Ship the change through Pull Request so
+   Pagefind reindexes automatically during `npm run build`.
+2. Sync cohort milestones and sandbox availability windows in this calendar so
+   growth, RevOps, and academic partners operate against the same timeline.
+3. Refresh supporting assets:
+   - Run `npm run ensure:whitepapers` if download descriptions change.
+   - Re-render diagrams under `public/static/diagrams/research/` when the FEDGEN
+     or Trace Synthesis topology evolves.
+4. Confirm the `/research/` route renders as expected by running `npm run lint`,
+   `npm run typecheck`, and `npm run build`. Capture updates in the PR summary so
+   reviewers know the automation suite executed.
 
 ## Onboarding Checklist
 

--- a/src/content/docs/content/cms.mdx
+++ b/src/content/docs/content/cms.mdx
@@ -7,7 +7,7 @@ description: This guide explains how marketing editors access the Decap CMS
   Both workflows build on the automation committed to the repo so there is no
   manual drift between content schemas, auth controls, and audit trails.
 sourcePath: content/CMS.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/content/information-architecture.mdx
+++ b/src/content/docs/content/information-architecture.mdx
@@ -7,7 +7,7 @@ description: Our marketing stack favors content-driven automation so teams scale
   how content collections, Astro templates, and shared components cooperate
   during `npm run build`.
 sourcePath: content/INFORMATION_ARCHITECTURE.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 
@@ -51,6 +51,29 @@ components cooperate during `npm run build`.
   button styling and copy length guidance.
 - `src/components/marketing/MarketingCtaRow.astro` prevents duplicate CTA markup while outlining
   performance and analytics considerations.
+
+## Homepage Product Stack Grid
+
+- **Source of truth:** The product stack grid ships inside `src/content/homepage/landing.mdx` as the
+  `modules` array. Follow the inline editorial contract to keep the BWCCUM → Themis → Mnemosyne →
+  Hermes → Morpheus cadence intact.
+- **Automation discipline:** Before editing module summaries or links, run `npm run ensure:whitepapers`
+  so regenerated PDFs (FEDGEN oversight, Sovereign AI assurance, Strategic automation playbook)
+  publish updated slugs into `assets/whitepapers/managed-assets.json`. Then execute `npm run lint`,
+  `npm run typecheck`, and `npm run build` to let CI mirror the refresh.
+- **Research hand-offs:** FEDGEN and Trace Synthesis references must point to the dossiers stored in
+  `docs/research/`. These Markdown files document access policies, download automation, and
+  investor-review cadence. Never link directly to R2 object URLs from marketing pages.
+- **Analytics alignment:** ProductModulesSection.tsx emits data attributes that assume the module
+  order in the MDX file. Any reorder requires updating analytics dashboards and the README table in
+  the same commit to keep revenue reporting accurate.
+
+## Research Dossiers
+
+- `docs/research/FEDGEN.md` — Tracks the capital oversight briefing workflow, signed URL
+  distribution cadence, and BWCCUM × Themis orchestration metrics investors see in PDFs.
+- `docs/research/TRACE_SYNTHESIS.md` — Documents trace aggregation, consent packaging, and the
+  Mnemosyne export hooks the homepage now references.
 
 Future additions (e.g., testimonial sliders, pricing tables) should follow the same pattern: create a
 component inside `src/components/marketing/`, annotate it thoroughly, and import it from page

--- a/src/content/docs/dev/accessibility.mdx
+++ b/src/content/docs/dev/accessibility.mdx
@@ -21,7 +21,7 @@ description: "| Frequency | Responsibility | Automation entrypoint | Notes | |
   `dist/ladle/` exist so both page templates and Ladle islands are scanned. Do
   **not** skip this phase; it is the final gate before production deploys. |"
 sourcePath: dev/ACCESSIBILITY.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/blog-analytics.mdx
+++ b/src/content/docs/dev/blog-analytics.mdx
@@ -6,7 +6,7 @@ description: This document captures the contract for the `blog-analytics`
   Worker, the D1 schema backing marketing dashboards, and the reviewer
   expectations for changes that touch analytics code paths.
 sourcePath: dev/BLOG-ANALYTICS.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/blog.mdx
+++ b/src/content/docs/dev/blog.mdx
@@ -7,7 +7,7 @@ description: This playbook documents how Apotheon.ai ships enterprise-ready blog
   `docs/content/BLOG_EDITORIAL.md` for narrative guidance—the checklist below
   focuses on developer automation.
 sourcePath: dev/BLOG.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/ci-cd.mdx
+++ b/src/content/docs/dev/ci-cd.mdx
@@ -8,7 +8,7 @@ description: The `CI` workflow codifies our enterprise readiness guardrails so
   [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) and executes
   automatically for pull requests and pushes to `main`.
 sourcePath: dev/CI_CD.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 
@@ -97,7 +97,10 @@ easy to debug issues without re-running a full build.
 
 Artifacts from Lighthouse, ZAP, Pagefind, and Gitleaks remain available for 14
 days. When triaging a failure, download the relevant archive from the Actions UI
-and review the bundled HTML/JSON reports.
+and review the bundled HTML/JSON reports. Release managers can pull the
+compression manifest from the same workflow run—follow the
+[Deployment & Edge Compression Playbook](/docs/dev/deployment/) for the ingestion
+steps that feed CDN configuration.
 
 ## Running the pipeline locally
 

--- a/src/content/docs/dev/deployment.mdx
+++ b/src/content/docs/dev/deployment.mdx
@@ -11,7 +11,7 @@ description: This playbook equips release managers with the exact steps required
   bespoke caching policies by hand—the pipeline already produces the data in a
   deterministic, audit-friendly shape.
 sourcePath: dev/DEPLOYMENT.md
-sourceLastModified: 2025-10-01T17:07:08.860Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/editorial.mdx
+++ b/src/content/docs/dev/editorial.mdx
@@ -9,7 +9,7 @@ description: This guide captures the repeatable workflow for planning, drafting,
   [`docs/content/CALENDAR.md`](../content/CALENDAR.md) so onboarding teammates
   can see how GrowthBook experiments map to each rolling content drop.
 sourcePath: dev/EDITORIAL.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/history.mdx
+++ b/src/content/docs/dev/history.mdx
@@ -7,7 +7,7 @@ description: This guide documents how Apotheon.ai teams extend the company
   buyers, regulators, and partners. Treat it as the canonical workflow—changes
   should ship through code review so downstream automation remains in sync.
 sourcePath: dev/HISTORY.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/homepage.mdx
+++ b/src/content/docs/dev/homepage.mdx
@@ -7,7 +7,7 @@ description: The homepage now sources hero, benefit, and CTA banner copy from
   guardrails so marketing, RevOps, and investor relations can collaborate
   without reverse engineering component implementations.
 sourcePath: dev/HOMEPAGE.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/i18n.mdx
+++ b/src/content/docs/dev/i18n.mdx
@@ -7,7 +7,7 @@ description: The marketing surface now ships with a QA-only locale switcher that
   toggle safely without leaking unfinished localisation work into production
   releases.
 sourcePath: dev/I18N.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/industries.mdx
+++ b/src/content/docs/dev/industries.mdx
@@ -7,7 +7,7 @@ description: Industry narratives moved into the dedicated
   messaging without touching templates. Every entry is validated by Zod at build
   time and rendered through hydration-free Astro components.
 sourcePath: dev/INDUSTRIES.md
-sourceLastModified: 2025-09-30T15:59:37.715Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/navigation.mdx
+++ b/src/content/docs/dev/navigation.mdx
@@ -7,7 +7,7 @@ description: Enterprise buyers expect deterministic navigation affordances that
   captures the smooth-scroll/focus contract introduced for the global header and
   how to validate it before releasing to staging.
 sourcePath: dev/NAVIGATION.md
-sourceLastModified: 2025-09-30T15:59:37.715Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/performance.mdx
+++ b/src/content/docs/dev/performance.mdx
@@ -6,13 +6,16 @@ description: This guide captures the automation that keeps our marketing surface
   fast, visually consistent, and regression friendly. Use it as a runbook when
   introducing new assets or reviewing pull requests that touch the rendering
   pipeline. For the Playwright workflow that enforces visual fidelity, see
-  [End-to-end testing & visual baselines](./TESTING.md).
+  [End-to-end testing & visual baselines](./TESTING.md). Deployment engineers
+  should pair these notes with the [Deployment & Edge Compression
+  Playbook](./DEPLOYMENT.md) to translate build artefacts into CDN cache rules
+  without manual guesswork.
 sourcePath: dev/PERFORMANCE.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 
-This guide captures the automation that keeps our marketing surface fast, visually consistent, and regression friendly. Use it as a runbook when introducing new assets or reviewing pull requests that touch the rendering pipeline. For the Playwright workflow that enforces visual fidelity, see [End-to-end testing & visual baselines](/docs/dev/testing/).
+This guide captures the automation that keeps our marketing surface fast, visually consistent, and regression friendly. Use it as a runbook when introducing new assets or reviewing pull requests that touch the rendering pipeline. For the Playwright workflow that enforces visual fidelity, see [End-to-end testing & visual baselines](/docs/dev/testing/). Deployment engineers should pair these notes with the [Deployment & Edge Compression Playbook](/docs/dev/deployment/) to translate build artefacts into CDN cache rules without manual guesswork.
 
 ## OpenGraph image workflow
 
@@ -36,6 +39,39 @@ This guide captures the automation that keeps our marketing surface fast, visual
 - `astro.config.mjs` reads the manifest at config time, injecting a global constant so layouts and components can surface preload/LCP annotations without hard-coding file paths.
 - `HomepageHero.astro` consults the manifest to decide whether to emit the AVIF preload (falling back to the existing frontmatter flag) and tags the media wrapper with `data-lcp-candidate` for perf tooling.
 
+## Navigation prefetch automation
+
+### PrefetchManager ↔ PrefetchController contract
+
+- `src/components/islands/PrefetchController.tsx` is the only surface that should instantiate the shared `PrefetchManager`. The island mounts in the global header and footer so speculative navigation becomes ubiquitous without bespoke page wiring.
+- The controller only enrols anchors that spread `PREFETCH_ATTRIBUTE_PAYLOAD` (`data-prefetch="intent"`); this explicit opt-in keeps marketing, docs, and authenticated surfaces aligned on which links are safe to hydrate ahead of time.
+- Eligible anchors are registered once and tracked through a shared runtime that is reference-counted. When the last island unmounts, the runtime tears down observers, listeners, and telemetry handles automatically to avoid ghost prefetches during onboarding modals or route transitions.
+- The MutationObserver watches for attribute changes and dynamically inserted anchors. Consumers can also dispatch the `PREFETCH_REFRESH_EVENT` to force a rescan after Astro Islands render client-side navigations.
+
+#### Eligibility and automation safeguards
+
+- `evaluateAnchorEligibility` guarantees that only same-origin, http(s) navigations without `download` attributes or `_blank` targets can be registered. Custom allow predicates can be layered on by surfaces that want to short-circuit prefetching based on business logic.
+- `respectSaveData` and the network `effectiveType` guard rails are enabled by default so low-bandwidth visitors never see speculative traffic. Setting `respectSaveData` to `false` in the manager config requires a compliance review.
+- `respectReducedMotion` defaults to `true`; pointer-enter heuristics disable themselves when `prefers-reduced-motion` is active so screen readers and high-sensitivity users do not encounter background network bursts. IntersectionObserver and focus-based triggers remain active because they align with explicit intent.
+- Prefetches are scheduled through `requestIdleCallback` (with a timeout fallback) and concurrency-limited to four in-flight requests, ensuring the feature plays nicely with the main thread and connection pools on lower-end devices.
+
+### Telemetry, aggregation, and monitoring
+
+- Every successful speculative fetch invokes `prefetchTelemetry.markPrefetched`, setting a signed sessionStorage flag for the normalised route. When the subsequent navigation timing beacon fires, the telemetry controller joins that flag with the recorded TTFB to determine whether the experience was warm or cold.
+- Aggregates are persisted in localStorage under `apotheon.prefetch.telemetry.v1` as capped histograms for each anonymised route. The controller trims to 48 routes per session, caps visit counters at 10,000, and normalises sensitive path segments (e.g., `/customers/:int/orders/:hash`) before egress.
+- **Flush requirements:** `prefetchTelemetry.submitPending` remains consent-gated. A dedicated zero-UI island (`PrefetchFlushOrchestrator`) now hydrates in both the global header and footer, wiring a singleton controller that waits for `umami-telemetry` approval before flushing on visibility changes and 60-second intervals. Custom layouts that omit the chrome must mount the island manually; otherwise aggregates stay in localStorage and downstream dashboards remain empty. Implementation notes live in `src/utils/navigation/prefetch-flush.client.ts`.
+- Dashboards:
+  - **Grafana – Prefetch Warmth Coverage** (`https://grafana.apotheon.ai/d/prefetch-nav/perf-prefetch`): Tracks warm vs. cold visit mix, TTFB histogram deltas, and the ratio of speculative hits to misses.
+  - **Looker – Prefetch Trend Report** (`https://looker.apotheon.ai/dashboards/prefetch-efficiency`): Surfaces 7/30-day regressions, route families with outlier TTFB buckets, and alert states mirrored into PagerDuty.
+- Alerts on those dashboards notify #web-perf-ops when warm coverage dips below 55% for any high-traffic route or when cold TTFB p95 exceeds the Lighthouse guardrail. Operators should expect a single consolidated batch event per active session; duplicate bursts typically indicate client-side storage resets or analytics proxy replays.
+
+### Troubleshooting runbook
+
+- **Anchors ignored** – Confirm the link spreads `PREFETCH_ATTRIBUTE_PAYLOAD` and does not include `download`, `_blank`, or cross-origin URLs. The `tests/e2e/navigation-prefetch.spec.ts` fixture page offers parity examples for quick regression checks.
+- **Prefetches never fire** – Inspect DevTools > Application > Storage to verify reduced-motion and Save-Data signals. Forcing those preferences locally should suppress pointer and idle triggers; if they do not, assert that `respectReducedMotion`/`respectSaveData` were not overridden.
+- **Telemetry gaps** – Inspect localStorage/sessionStorage for the `apotheon.prefetch.*` keys. Missing entries usually mean prefetches never fired; if data is present but dashboards are blank, confirm an owning surface is calling `prefetchTelemetry.submitPending` after analytics consent. When submissions do occur, tail the analytics proxy Worker logs (Cloudflare dashboard → Analytics Proxy → Recent logs) for schema validation errors or rate limit denials.
+- **Dashboard regression** – Review the most recent deploy for changes to `prefetch-manager.ts` or link templates. If the Worker is returning 428 errors, Cloudflare may not be appending geo headers due to a configuration drift—check the zone worker routes first.
+
 ## Lighthouse calibration
 
 Run `npm run lighthouse:calibrate` to generate fresh JSON audits under `reports/lighthouse/`. The script:
@@ -54,6 +90,13 @@ Run `npm run lighthouse:calibrate` to generate fresh JSON audits under `reports/
 - [ ] Review both `artifacts/lighthouse/desktop` and `artifacts/lighthouse/mobile` outputs when performance regressions are suspected; the latter represents our 4G mobile budget.
 - [ ] Run `npm run lighthouse:calibrate` after large visual overhauls and commit updated reports if the baseline changes.
 - [ ] Refresh Playwright theme fixtures via `npm run test:e2e:update-theme-visual` (documented in [TESTING.md](/docs/dev/testing/)) when UI adjustments are intentional so CI inherits deterministic screenshots.
+
+## CI validation for navigation prefetch
+
+- **Unit coverage** – `vitest` executes `src/utils/__tests__/prefetch-manager.test.ts` and `src/utils/navigation/__tests__/prefetch-telemetry.test.ts`, hardening the eligibility decision tree, reduced-motion enforcement, TTL expiries, anonymisation helpers, and analytics submission contract.
+- **Playwright suite** – `tests/e2e/navigation-prefetch.spec.ts` visits the `/testing/navigation-prefetch` fixture and asserts pointer, intersection, automation safeguards, **and** the consent-gated flush orchestrator. The spec preloads aggregates, toggles consent, and verifies the analytics proxy receives a `prefetch_navigation_metrics` batch so CI continuously exercises the Worker contract.
+- **Lighthouse budgets** – `npm run lighthouse:ci` monitors the TTFB and LCP deltas caused by speculative navigation. Prefetch regressions typically manifest as slower mobile LCP; the calibration workflow keeps the baseline aligned with the dashboards referenced in the telemetry section.
+- **New specification docs** – Any change to the contract or telemetry flow must update this file and the Playwright fixture markup so CI and documentation remain in sync.
 
 ## Rollback guidance
 

--- a/src/content/docs/dev/privacy.mdx
+++ b/src/content/docs/dev/privacy.mdx
@@ -7,7 +7,7 @@ description: This document describes how Apothéon captures analytics while
   teams should use it as the canonical reference when shipping new telemetry or
   reviewing PRs.
 sourcePath: dev/PRIVACY.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/role-targeting.mdx
+++ b/src/content/docs/dev/role-targeting.mdx
@@ -7,7 +7,7 @@ description: Apotheon.ai marketing surfaces (homepage hero, contact form, docs
   Append `?role=<id>` to any marketing URL and the system hydrates curated copy,
   CTAs, and analytics automatically.
 sourcePath: dev/ROLE-TARGETING.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/seo.mdx
+++ b/src/content/docs/dev/seo.mdx
@@ -7,7 +7,7 @@ description: This document captures the conventions that keep Apotheon.ai's
   guidance below as the source of truth when extending metadata, structured
   data, or search artifacts.
 sourcePath: dev/SEO.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 

--- a/src/content/docs/dev/solutions.mdx
+++ b/src/content/docs/dev/solutions.mdx
@@ -8,7 +8,7 @@ description: The dedicated solutions collection (`src/content/solutions/`) keeps
   frontmatter must satisfy the schema defined in
   `src/content/solutions/index.ts`.
 sourcePath: dev/SOLUTIONS.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T18:30:39.439Z
 tags: []
 ---
 
@@ -16,6 +16,16 @@ The dedicated solutions collection (`src/content/solutions/`) keeps product stor
 fully structured so Astro templates render hydration-free sections in a consistent order.
 Each entry is a Markdown or MDX file whose frontmatter must satisfy the schema defined in
 `src/content/solutions/index.ts`.
+
+## Current Solution Roster
+
+- `bwccum` — BWC-CUM Autonomous Control Mesh orchestrating continuous control enforcement.
+- `clio` — Clio Revenue Intelligence aligning GTM pipelines and executive narratives.
+- `hermes` — Hermes Automation Cloud powering workflow orchestration and human-in-the-loop review.
+- `mnemosyne` — Mnemosyne Activation Fabric governing consent-aware activation.
+- `morpheus` — Morpheus Observability Fabric streaming telemetry for automated guardrails.
+- `nova` — Nova Workbench securing experimentation pipelines for AI teams.
+- `themis` — Themis Governance Control Plane centralizing policy evidence and attestation.
 
 ## Required Frontmatter Fields
 

--- a/src/content/docs/dev/testing.mdx
+++ b/src/content/docs/dev/testing.mdx
@@ -8,7 +8,7 @@ description: This runbook explains how we exercise the Playwright suite, keep
   below before touching the marketing surface or shipping new design tokens so
   the CI pipeline inherits deterministic pixels.
 sourcePath: dev/TESTING.md
-sourceLastModified: 2025-09-30T16:35:03.665Z
+sourceLastModified: 2025-10-04T15:54:28.567Z
 tags: []
 ---
 
@@ -98,6 +98,18 @@ forking scripts:
 Set one of the snapshot flags to `1` to regenerate fixtures during bespoke automation (e.g., scheduled jobs). When unset,
 the suite fails with actionable messaging and uploads the drifted assets for inspection.
 
+## Structural HTML validation
+
+`npm run lint:html` wraps `scripts/ci/run-html-validate.mjs`, which shells into the local `html-validate` binary so we gate the exact HTML that Astro and Ladle emitted. The harness expects `dist/` and `dist/ladle/` to exist ahead of time, mirroring how CI runs inside a sandbox with no network access. Run the following before invoking the validator locally:
+
+```bash
+npm run build
+npm run ladle:build
+npm run lint:html
+```
+
+The validator prints a summary of scanned files plus rule violations (missing `alt` text, duplicate `<main>` landmarks, implicit buttons, etc.). Fixtures live under `tests/fixtures/html-validator/` so we keep deterministic reproducers for new rules or regressions.
+
 ## Link linting & content hygiene
 
 `npm run lint:links` wraps the enterprise lychee binary so link hygiene runs alongside ESLint, Vale, and the other quality
@@ -110,11 +122,17 @@ broken references.
   hermetic CI, so use `npm run lint:links -- --online` when you explicitly want to exercise production URLs.
 - **Artifact trail.** Results land in `artifacts/link-check/report.json`; commit or upload this file when auditors need
   evidence of the scan.
-- **Binary provisioning.** The vendored CLI lives under `vendor/lychee`. Prebuilt archives now span Linux (x64/arm64/armv7),
-  Apple Silicon and Intel macOS, plus Windows x64 so every platform our auditors use resolves to a deterministic binary.
-  If the environment cannot reach GitHub, set `APOTHEON_LYCHEE_ARCHIVE_URL` to an internal mirror,
-  `APOTHEON_LYCHEE_ARCHIVE_PATH` to a pre-seeded tarball, or `APOTHEON_LYCHEE_SKIP_DOWNLOAD=1` once the binary is present.
-  Use `HOMEPAGE_HERO_DISABLE_RENDER=1` when you do prime the static build to avoid Python/Pillow requirements.
+- **Astro CLI invocation.** The wrapper calls the `node_modules/.bin/astro` shim directly, so extend it with subcommands
+  only (for example `['build', '--outDir', …]`). Passing a leading `astro` string double-prefixes the binary and breaks
+  the static build.
+- **Binary provisioning.** The vendored CLI lives under `vendor/lychee` and downloads its architecture-specific binary into
+  `vendor/lychee/vendor/` during `npm install`. Prebuilt archives now cover Linux (x64/arm64/armv7), Apple Silicon and Intel
+  macOS, plus Windows x64 so enterprise fleets stay deterministic regardless of hardware refresh cycles. The executable is
+  gitignored to satisfy the "no large binaries" policy, so
+  pre-seed that directory before installing when you work completely offline. Set `APOTHEON_LYCHEE_ARCHIVE_URL` to an
+  internal mirror, `APOTHEON_LYCHEE_ARCHIVE_PATH` to a pre-seeded tarball, or `APOTHEON_LYCHEE_SKIP_DOWNLOAD=1` once the
+  binary is present. Use `HOMEPAGE_HERO_DISABLE_RENDER=1` when you do prime the static build to avoid Python/Pillow
+  requirements.
 
 ## Troubleshooting deterministic captures
 

--- a/src/content/docs/dev/whitepapers.mdx
+++ b/src/content/docs/dev/whitepapers.mdx
@@ -6,7 +6,7 @@ description: Enterprise whitepapers run through a fully automated pipeline so
   regulated teams can trust every download and reviewer can audit the trail
   end-to-end.
 sourcePath: dev/WHITEPAPERS.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/dev/workflows.mdx
+++ b/src/content/docs/dev/workflows.mdx
@@ -7,7 +7,7 @@ description: The `/about/contact/` experience now routes through a Cloudflare
   document outlines how the pipeline is wired together and what automation keeps
   it healthy in pre-production environments.
 sourcePath: dev/WORKFLOWS.md
-sourceLastModified: 2025-09-30T15:59:37.715Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 
@@ -91,6 +91,46 @@ pre-production environments.
   [`reports/automation/2025-02-19-theme-visual-regeneration.md`](https://github.com/apotheon-ai/apotheon.ai/blob/main/reports/automation/2025-02-19-theme-visual-regeneration.md)
   before adjusting the contract so future pull requests inherit the audited
   route × theme matrix.
+
+### Contact form accessibility contract
+
+The `/about/contact/` island ships a deterministic accessibility surface so QA
+and assistive technology users receive the same remediation cues on every
+release:
+
+- **Deterministic error identifiers.** Each control mirrors the schema-issued
+  issue code with a prefixed error ID (`contact-error-name`,
+  `contact-error-email`, `contact-error-company`, `contact-error-intent`,
+  `contact-error-message`, `contact-error-turnstile`). These IDs are
+  concatenated with any persistent helper text (for example `email-help`) inside
+  `aria-describedby` to ensure every invalid field references all supporting
+  guidance.
+- **Explicit ARIA wiring.** Invalid fields toggle `aria-invalid="true"` and
+  register the deterministic IDs in `aria-describedby`. The `<form>` element is
+  labelled by its `<legend>` and references the dedicated status region via
+  `aria-describedby="contact-form-status"`, while the submit button exposes
+  `aria-live="polite"` updates for users navigating with virtual cursors.
+- **Status announcements.** The live region (`role="status"`, `id` matching the
+  deterministic descriptor) emits success, validation, and worker rejection
+  copy. It sets a `data-state` flag so the e2e suite can validate error,
+  warning, and success pathways without relying on text heuristics.
+
+### Internationalization touchpoints
+
+- Text strings, validation prompts, and status announcements for the contact
+  journey live under `src/i18n/<locale>/common.json` in the `contact` namespace.
+  Update every locale bundle and confirm the Astro i18next registration mirrors
+  the new keys before merging.
+- When extending intents or helper copy, update the structured translations and
+  validate that `ContactForm` consumes the namespace via `useTranslation`. This
+  keeps the deterministic IDs paired with the correct localized messaging.
+- Regression coverage exists in:
+  - `tests/unit/accessibility-islands.spec.tsx` for DOM-level ARIA contracts and
+    deterministic error IDs.
+  - `tests/e2e/contact-form.spec.ts` for screen reader mode announcements,
+    worker-driven failures, and valid submission flows under localization-aware
+    routes. Run `npm run test` and `npm run test:e2e` after localization edits to
+    preserve the accessibility contract.
 
 ### Node.js engine baseline
 

--- a/src/content/docs/infra/alternatives.mdx
+++ b/src/content/docs/infra/alternatives.mdx
@@ -9,7 +9,7 @@ description: This register lists open-source or zero-cost (for small workloads)
   integration notes covering security boundaries, data flow implications, and
   performance considerations.
 sourcePath: infra/ALTERNATIVES.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/infra/hosting.mdx
+++ b/src/content/docs/infra/hosting.mdx
@@ -6,7 +6,7 @@ description: This document captures the operational contracts our hosting
   providers must honor so the static Astro build remains resilient under failure
   conditions.
 sourcePath: infra/HOSTING.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/launch/go-live-checklist.mdx
+++ b/src/content/docs/launch/go-live-checklist.mdx
@@ -6,7 +6,7 @@ description: This playbook codifies the enterprise-grade launch routine for
   Apotheon.ai. Every step favors automation over one-off console work so we can
   rehearse, audit, and repeat the launch procedure without drift.
 sourcePath: launch/GO-LIVE_CHECKLIST.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 
@@ -40,6 +40,7 @@ synthetic_health && wrangler tail`) to confirm `/api/contact` and
 
 - Trigger the warmup script (`npm run build && node scripts/ci/ensure-ladle-output.mjs`)
   to prime static assets and OG imagery before the first user hits the site.
+- Regenerate the static bundles (`npm run build && npm run ladle:build`) and run `npm run lint:html` so the html-validate gate signs off on the launch-ready markup before cache warmup begins.
 - Fire the synthetic Worker immediately after warmup so the contact and
   whitepaper caches contain fresh responses. This also seeds D1 with the first
   production run for observability.

--- a/src/content/docs/research/fedgen.mdx
+++ b/src/content/docs/research/fedgen.mdx
@@ -1,0 +1,37 @@
+---
+title: FEDGEN Capital Oversight Briefing
+category: research
+categoryLabel: Research
+description: 1. Author or update the MDX source under `src/content/whitepapers/`
+  (e.g., `fedgen-operational-oversight.mdx`). 2. Run `npm run
+  ensure:whitepapers` to regenerate PDFs and update
+  `assets/whitepapers/managed-assets.json` with fresh checksums. 3. Execute `npm
+  run test && npm run build` to rebuild automation reports and ensure CI parity
+  before publishing. 4. Commit the regenerated manifest entries alongside any
+  README or landing page copy updates so reviewers can trace metrics to source
+  artifacts.
+sourcePath: research/FEDGEN.md
+sourceLastModified: 2025-10-04T15:54:28.571Z
+tags: []
+---
+
+> **Purpose:** Document the pipeline that generates and distributes the FEDGEN (Federated Governance) investor whitepaper referenced across the README, homepage product stack, and diligence packets.
+
+## Asset Generation Workflow
+
+1. Author or update the MDX source under `src/content/whitepapers/` (e.g., `fedgen-operational-oversight.mdx`).
+2. Run `npm run ensure:whitepapers` to regenerate PDFs and update `assets/whitepapers/managed-assets.json` with fresh checksums.
+3. Execute `npm run test && npm run build` to rebuild automation reports and ensure CI parity before publishing.
+4. Commit the regenerated manifest entries alongside any README or landing page copy updates so reviewers can trace metrics to source artifacts.
+
+## Distribution & Access Controls
+
+- **Primary funnel:** `/about/white-papers/?whitepaperSlug=apotheon-investor-brief#whitepaper-request` issues signed URLs via the Workers delivery proxy. Update the slug once the dedicated FEDGEN MDX ships.
+- **Synthetic monitoring:** `npm run test:synthetic` validates that the whitepaper Worker can mint download URLs and persist audit trails to D1.
+- **Investor notifications:** Coordinate with RevOps to schedule GOV/IR email drops immediately after PDFs regenerate. The BWCCUM orchestration metrics in the README table must match the PDF appendix.
+
+## Signal Taxonomy Custody
+
+- **Coverage:** Runtime metrics exported from BWCCUM lanes, policy attestation deltas from Themis, and consent summaries from Mnemosyne.
+- **Storage:** Persist sanitized aggregates in the FEDGEN section of `assets/whitepapers/managed-assets.json`. Never embed raw customer data.
+- **Review cadence:** Quarterly (or sooner if regulatory policy shifts). Always rerun `npm run ensure:whitepapers` and refresh README metrics in the same change set.

--- a/src/content/docs/research/trace-synthesis.mdx
+++ b/src/content/docs/research/trace-synthesis.mdx
@@ -1,0 +1,33 @@
+---
+title: Trace Synthesis Research Dossier
+category: research
+categoryLabel: Research
+description: 1. Capture orchestrated traces from BWCCUM lanes with PII scrubbed
+  at the edge. 2. Themis evaluates compliance posture and annotates the dataset
+  with jurisdictional gating metadata. 3. Mnemosyne packages approved aggregates
+  for activation while Hermes exposes scenario sandboxes for RevOps and partner
+  enablement.
+sourcePath: research/TRACE_SYNTHESIS.md
+sourceLastModified: 2025-10-04T15:54:28.571Z
+tags: []
+---
+
+> **Purpose:** Centralize the automation guardrails, consent policies, and distribution hooks for the Trace Synthesis research cited across homepage modules and investor collateral.
+
+## Data Pipeline Overview
+
+1. Capture orchestrated traces from BWCCUM lanes with PII scrubbed at the edge.
+2. Themis evaluates compliance posture and annotates the dataset with jurisdictional gating metadata.
+3. Mnemosyne packages approved aggregates for activation while Hermes exposes scenario sandboxes for RevOps and partner enablement.
+
+## Drift Appendix Automation Contract
+
+- **Source MDX:** `src/content/whitepapers/trace-synthesis.mdx` (placeholder until research publish). Update metrics directly in MDX so the PDF export stays authoritative.
+- **Generation:** Run `npm run ensure:whitepapers` to produce the appendix PDF and refresh the manifest ledger before touching README or landing summaries.
+- **Verification:** Execute `npm run lint && npm run typecheck && npm run build` to confirm automation parity and Lighthouse budgets after copy changes.
+
+## Download & Consent Workflow
+
+- **Investor access:** Route visitors through `/about/white-papers/?whitepaperSlug=strategic-automation-playbook#whitepaper-request` until the dedicated Trace Synthesis slug ships.
+- **Consent logging:** The whitepaper Worker persists consent receipts to D1; confirm the records via `npm run test:synthetic` in CI for every change.
+- **Revocation handling:** Mnemosyne automatically propagates opt-outs to BWCCUM lanes. Document escalations in the consent ledger referenced in homepage copy.

--- a/src/content/docs/security/font-hosting.mdx
+++ b/src/content/docs/security/font-hosting.mdx
@@ -7,7 +7,7 @@ description: Enterprise CSP requirements prohibit calls to third-party font
   the same origin as the rest of the site. This file documents the repeatable
   workflow for teams.
 sourcePath: security/FONT_HOSTING.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/security/incident-response.mdx
+++ b/src/content/docs/security/incident-response.mdx
@@ -6,7 +6,7 @@ description: This guide codifies the security incident process for the
   Apotheon.ai edge surface. It ties tabletop exercises, runbook usage, and
   backup restore verification into a single, opinionated workflow.
 sourcePath: security/INCIDENT_RESPONSE.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/security/local-https.mdx
+++ b/src/content/docs/security/local-https.mdx
@@ -7,7 +7,7 @@ description: Enterprise QA requires parity with production transport security.
   configuration, and CSP report capture so engineers can exercise real-world
   browser behaviour before shipping.
 sourcePath: security/LOCAL_HTTPS.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/security/runbook-contact-abuse.mdx
+++ b/src/content/docs/security/runbook-contact-abuse.mdx
@@ -8,7 +8,7 @@ description: This playbook guides on-call responders through triaging
   trails so operators can jump from an alert directly to actionable remediation
   tasks.
 sourcePath: security/RUNBOOK_CONTACT_ABUSE.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/security/runbook-csp-triage.mdx
+++ b/src/content/docs/security/runbook-csp-triage.mdx
@@ -8,7 +8,7 @@ description: Security engineers use this guide to pivot from CSP violation
   containment actions. The Worker batches Reporting API payloads, persists them
   to `REPORTS`, and fans out high-severity hits to the configured alert webhook.
 sourcePath: security/RUNBOOK_CSP_Triage.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/security/runbook-r2-incident.mdx
+++ b/src/content/docs/security/runbook-r2-incident.mdx
@@ -7,7 +7,7 @@ description: This document covers containment and recovery steps when the
   backing R2 bucket (`WHITEPAPER_ASSETS`) is degraded, compromised, or
   unavailable.
 sourcePath: security/RUNBOOK_R2_INCIDENT.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T15:54:28.571Z
 tags: []
 ---
 

--- a/src/content/docs/workplan/epics-and-work-items.mdx
+++ b/src/content/docs/workplan/epics-and-work-items.mdx
@@ -4,7 +4,7 @@ category: workplan
 categoryLabel: Workplan
 description: docs/workplan/EPICS_AND_WORK_ITEMS.md
 sourcePath: workplan/EPICS_AND_WORK_ITEMS.md
-sourceLastModified: 2025-09-30T04:05:36.323Z
+sourceLastModified: 2025-10-04T18:30:39.439Z
 tags: []
 ---
 
@@ -60,14 +60,14 @@ docs/workplan/EPICS_AND_WORK_ITEMS.md
 - **Deliverables**
   - `brand/STYLEGUIDE.md`: palette (dark & light), typography scale, spacing, radii, shadows.
   - Tokenized **Tailwind config**; prefers system fonts for perf; variable fonts optional (subset + preload).
-  - Icon set: custom SVGs for **Clio, Hermes, THEMIS, Morpheus, Mnemosyne**, and 6 industries.
+  - Icon set: custom SVGs for **BWC-CUM, Clio, Hermes, THEMIS, Morpheus, Mnemosyne**, and 6 industries.
   - Favicon + PWA icons (use provided 512x512 asset).
   - Component library docs (Storybook **Chromatic** alt → **Ladle** OSS if lighter).
 
 - **Work Items**
   - **Document the brand system** — Create `docs/brand/STYLEGUIDE.md` capturing the light/dark palettes, typography scale, spacing/radii/shadow tokens, usage tables, and instructions for running an automated WCAG contrast audit script so designers and engineers share a single source of truth.
   - **Codify multi-theme design tokens** — Expand `tailwind.config.mjs` (and supporting files such as `src/styles/global.css` and a new `src/styles/tokens.(css|ts)`) to expose semantic color, typography, spacing, radii, and shadow tokens via CSS variables for both themes, prefer the system stack before optional variable fonts to eliminate layout shift, and annotate the tokens with inline comments.
-  - **Automate the icon pipeline** — Produce custom SVGs for Clio, Hermes, THEMIS, Morpheus, Mnemosyne, and the six industries under `public/static/icons/brand/`, wire an `svgo` configuration plus an `npm run icons:build` script to normalize/optimize them (and optionally emit React wrappers), and document naming/usage guidance in the style guide.
+  - **Automate the icon pipeline** — Produce custom SVGs for BWC-CUM, Clio, Hermes, THEMIS, Morpheus, Mnemosyne, and the six industries under `public/static/icons/brand/`, wire an `svgo` configuration plus an `npm run icons:build` script to normalize/optimize them (and optionally emit React wrappers), and document naming/usage guidance in the style guide.
   - **Automate favicons & manifest metadata** — Use the existing 512×512 master asset to generate favicon/PWA sizes via a script such as `npm run brand:favicons` (pwa-asset-generator or Sharp), refresh `public/favicon.ico`, update `public/manifest.json` and the `<link rel>` tags in `src/layouts/BaseLayout.astro`, and record the regeneration workflow in the style guide.
   - **Stand up component documentation** — Add Ladle (preferred OSS) or Storybook with scripts (`npm run ladle`, `npm run ladle:build`), author stories that showcase the design tokens and navigation components with extensive notes, hook the tool into automation/CI for visual or accessibility checks, and document the workflow for designers/developers.
 

--- a/src/content/homepage/index.ts
+++ b/src/content/homepage/index.ts
@@ -235,6 +235,35 @@ export const homepageSchema = z.object({
             .describe('Configuration for the investor banner button'),
         })
         .describe('Investor enablement banner copy + CTA metadata'),
+      /** Research banner spotlights the academic hub + sandbox automation path. */
+      research: z
+        .object({
+          /** Banner headline rendered as an <h2>. */
+          heading: z.string().min(1).describe('Research banner headline copy'),
+          /** Supporting copy framing partnerships, integrations, or download bundles. */
+          body: z
+            .string()
+            .min(1)
+            .describe('Body copy summarizing research partnerships and automation workflows'),
+          /** Optional secondary note for submission deadlines or cohort cadence. */
+          secondaryText: z
+            .string()
+            .min(1)
+            .optional()
+            .describe('Optional secondary message highlighting cohort cadence or response SLAs'),
+          /** CTA metadata ensures analytics + accessibility remain synchronized. */
+          cta: z
+            .object({
+              label: z.string().min(1).describe('Visible CTA label copy'),
+              href: z.string().min(1).describe('Destination URL for the research CTA'),
+              ariaLabel: z
+                .string()
+                .min(1)
+                .describe('Accessible label clarifying the research-focused action'),
+            })
+            .describe('Configuration for the research banner button'),
+        })
+        .describe('Research hub banner copy + CTA metadata'),
       /** Demo banner routes prospects into guided evaluations managed by RevOps. */
       demo: z
         .object({
@@ -282,4 +311,5 @@ export type HomepageIndustriesPreview = NonNullable<HomepageHeroContent['industr
 export type HomepageBenefit = HomepageHeroContent['benefits'][number];
 export type HomepageCtaBanners = HomepageHeroContent['ctaBanners'];
 export type HomepageInvestorBanner = HomepageCtaBanners['investor'];
+export type HomepageResearchBanner = HomepageCtaBanners['research'];
 export type HomepageDemoBanner = HomepageCtaBanners['demo'];

--- a/src/content/homepage/landing.mdx
+++ b/src/content/homepage/landing.mdx
@@ -105,6 +105,14 @@ ctaBanners:
       label: 'Access investor materials'
       href: '/about/investors/'
       ariaLabel: 'Navigate to the Apotheon.ai investor relations overview before requesting materials'
+  research:
+    heading: 'Research partnerships & sandboxes'
+    body: 'Coordinate academic cohorts, FEDGEN integrations, and Trace Synthesis sandboxes without bespoke intake workflows.'
+    secondaryText: 'Research requests route to dedicated RevOps analysts during %officeHours%.'
+    cta:
+      label: 'Explore research hub'
+      href: '/research'
+      ariaLabel: 'Navigate to the Apotheon.ai research and academic partnerships hub'
   demo:
     heading: 'Schedule a platform field demo'
     body: 'Partner with a solutions architect for a guided build of governance policies, orchestration flows, and telemetry dashboards.'

--- a/src/content/marketing/research.mdx
+++ b/src/content/marketing/research.mdx
@@ -1,0 +1,62 @@
+---
+title: Research & Academic Partnerships
+summary: Partner with Apotheon.ai to co-develop regulated AI controls, synthesize evaluation traces, and access governed sandboxes wired for compliance research.
+heroCtaLabel: Request sandbox credentials
+order: 8
+---
+
+[//]: # 'RESEARCH PLAYBOOK: Update cohort + integration tables in lockstep with Pagefind indexing. Run npm run build so the static search bundle captures edits immediately.'
+
+## Academic partnership program
+
+We operate multi-year memoranda of understanding with universities and federal labs that specialize in resilient automation, policy assurance, and evaluation science.
+
+- **Joint research boards** at MITRE, CMU, and Stanford review every dataset before it enters the platform, aligning with IRB approvals and export-control guidance.
+- **Dual-rail publication tracks** allow partners to ship peer-reviewed papers alongside applied playbooks surfaced in the Apotheon.ai docs hub.
+- **Evidence-first collaboration** keeps board minutes, experiment telemetry, and audit artifacts in the same ledger so compliance checkpoints are never lost.
+
+> Contact [research@apotheon.ai](mailto:research@apotheon.ai) to nominate new cohort members. We rotate invitations twice per year and publish selections in the handbook changelog.
+
+### Active partner cohorts
+
+| Cohort                   | Focus area                                                            | Current milestone                                                                                   |
+| ------------------------ | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Sovereign AI Observatory | Zero-knowledge proof systems for multinational data residency         | Q3: Deploying FedRAMP-aligned verification harnesses inside Nova tenants                            |
+| Trace Ethics Consortium  | Bias detection and remediation frameworks across healthcare + finance | Q2: Publishing comparative drift analysis results via the Sovereign AI Assurance whitepaper refresh |
+| Mission Systems Lab      | Field-deployable AI orchestration for classified environments         | Q4: Delivering IL5 sandbox blueprints with attested runtime policies                                |
+
+[//]: # 'SANDBOX ACCESS: Research program owners must sync new cohorts with docs/content/CALENDAR.md so release cadences stay aligned.'
+
+## FEDGEN and Trace Synthesis integration
+
+![FEDGEN and Trace Synthesis data exchange diagram](/static/diagrams/research/fedgen-trace-synthesis.svg)
+
+The research hub federates deterministic provenance (FEDGEN) with Trace Synthesis replay pipelines so every experiment emits audit-ready telemetry.
+
+1. **FEDGEN broker** validates partner uploads against consent lineage policies, encrypts corpora using tenant-managed keys, and stages zero-copy escrow in R2.
+2. **Trace Synthesis fabric** distills features, applies fairness instrumentation, and exports replay bundles with deterministic seeds for reproducibility.
+3. **Governed Nova sandboxes** hydrate the replay bundles, enforcing adaptive guardrails through Clio before researchers access controlled GPUs.
+
+Each stage produces signed manifests stored alongside the [Sovereign AI Assurance whitepaper](/about/white-papers/), making compliance reviews self-service for legal and policy stakeholders.
+
+## Researcher onboarding guidance
+
+- **Sandbox provisioning** — Submit a request via the hero CTA or [RevOps contact form](/about/contact/?team=research) with your institution’s compliance officer copied. RevOps automates background checks and drops credentials within one business day.
+- **Data ingestion** — Run `npm run ensure:research-intake -- --dry-run` locally (documented in the private ops handbook) before transferring corpora to confirm schema alignment. The workflow emits manifests consumed by FEDGEN.
+- **Publication workflow** — Draft findings in MDX under `src/content/marketing/research/` child folders. Include `[//]: # "PUBLISHING"` annotations so peers understand required automation. Ship updates through Pull Requests to trigger Pagefind reindexing.
+
+### Downloadable resources
+
+| Resource                                              | Description                                                                                  | Maintainer             |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------- |
+| [Sovereign AI Assurance](/about/white-papers/)        | Compliance blueprint covering attestation exchange workflows referenced by FEDGEN sandboxes. | compliance@apotheon.ai |
+| [Strategic Automation Playbook](/about/white-papers/) | Operational playbook aligning Trace Synthesis insights with enterprise rollout cadences.     | revops@apotheon.ai     |
+| [Nova AI Research Workbench](/solutions/nova/)        | Module overview detailing how Nova isolates research tenants and enforces export controls.   | product@apotheon.ai    |
+
+> **Automation note:** Whitepaper metadata syncs from `src/content/whitepapers`. Run `npm run ensure:whitepapers` before updating download descriptions so checksum manifests stay aligned with the delivery Worker.
+
+## Next steps
+
+- Review the [downloadable resources](#downloadable-resources) table and capture experiment intents in `docs/content/CALENDAR.md`.
+- Use the sandbox CTA to request credentials, then coordinate integration testing with the FEDGEN team via the Trace Synthesis Slack bridge.
+- Schedule quarterly retrospectives with Apotheon.ai research program managers to ensure academic roadmaps and enterprise releases stay synchronized.

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -138,6 +138,24 @@
           }
         }
       },
+      "research": {
+        "label": "Research",
+        "description": "Academic partnerships, Trace Synthesis integrations, and sandbox provisioning guidance.",
+        "links": {
+          "hub": {
+            "label": "Research partnerships hub",
+            "description": "Program overview, FEDGEN workflows, and publication guidance."
+          },
+          "nova": {
+            "label": "Nova research tenants",
+            "description": "Isolation controls and export governance for academic workloads."
+          },
+          "whitepapers": {
+            "label": "Sovereign AI Assurance",
+            "description": "Download attestation playbooks and Trace Synthesis integration briefs."
+          }
+        }
+      },
       "securityRunbooks": {
         "label": "Security Runbooks",
         "description": "Field-ready incident guides aligned with the security playbooks introduced in issue #3.",
@@ -218,6 +236,9 @@
       },
       "industries": {
         "title": "Industries"
+      },
+      "research": {
+        "title": "Research"
       },
       "company": {
         "title": "Company"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import IndustriesPreview from '../components/homepage/IndustriesPreview.astro';
 import InvestorBanner from '../components/homepage/InvestorBanner.astro';
 import PlatformBenefits from '../components/homepage/PlatformBenefits.astro';
 import ProductModules from '../components/homepage/ProductModules.astro';
+import ResearchBanner from '../components/homepage/ResearchBanner.astro';
 import LiveClock from '../components/islands/LiveClock';
 import WelcomeTour from '../components/islands/WelcomeTour';
 import {
@@ -272,6 +273,7 @@ const welcomeTourSteps = [
     }
 
     <InvestorBanner banner={homepageEntry.data.ctaBanners.investor} />
+    <ResearchBanner banner={homepageEntry.data.ctaBanners.research} />
     <DemoBanner banner={homepageEntry.data.ctaBanners.demo} />
 
     <!--

--- a/src/pages/research/index.astro
+++ b/src/pages/research/index.astro
@@ -1,0 +1,100 @@
+---
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+import MarketingCtaRow from '../../components/marketing/MarketingCtaRow.astro';
+import MarketingHero from '../../components/marketing/MarketingHero.astro';
+import MarketingShell from '../../components/marketing/MarketingShell.astro';
+import SchemaScript from '../../components/seo/SchemaScript.astro';
+import { createMarketingEntryTrail } from '../../utils/breadcrumbs';
+import { buildBreadcrumbSchema, buildHowToSchema } from '../../utils/seo';
+
+const entries = await getCollection('marketing', ({ slug }) => slug === 'research');
+const researchEntry = entries[0];
+
+if (!researchEntry) {
+  throw new Error(
+    'Research marketing entry missing. Ensure src/content/marketing/research.mdx is committed before building /research/.',
+  );
+}
+
+const { data } = researchEntry;
+const { Content } = await researchEntry.render();
+const heroCopy =
+  data.summary ??
+  'Partner with the Apotheon.ai research program to align academic rigor, Trace Synthesis telemetry, and governed sandboxes.';
+const heroCtaHref = '/about/contact/?team=research&intent=sandbox-access';
+const heroCtaDescription =
+  'Routes directly to the research RevOps queue so sandbox provisioning and compliance onboarding finish inside 1 business day.';
+const breadcrumbs = createMarketingEntryTrail(researchEntry as CollectionEntry<'marketing'>);
+const siteOrigin = Astro.site?.origin ?? Astro.url.origin;
+const breadcrumbSchema = buildBreadcrumbSchema(breadcrumbs, siteOrigin);
+const onboardingSchema = buildHowToSchema({
+  name: 'Research sandbox onboarding workflow',
+  description:
+    'Steps researchers follow to access governed Nova sandboxes and feed Trace Synthesis pipelines with institutionally approved corpora.',
+  steps: [
+    {
+      name: 'Submit sandbox request',
+      text: 'Use the Request sandbox credentials CTA or the RevOps contact form with team=research to emit an intake event for RevOps automation.',
+      url: `${siteOrigin}/about/contact/?team=research`,
+    },
+    {
+      name: 'Validate datasets with FEDGEN dry-run',
+      text: 'Execute npm run ensure:research-intake -- --dry-run to generate manifests and confirm consent lineage before transferring corpora.',
+      url: `${siteOrigin}/docs/dev/workflows/`,
+    },
+    {
+      name: 'Activate Trace Synthesis replay bundles',
+      text: 'Coordinate with Trace Synthesis operators to hydrate Nova sandboxes and attach telemetry subscriptions for experiment reviews.',
+      url: `${siteOrigin}/solutions/nova/`,
+    },
+  ],
+});
+const schemaPayload = [breadcrumbSchema, onboardingSchema];
+const ctaItems = [
+  {
+    title: 'Download Sovereign AI Assurance',
+    description:
+      'Review the compliance ledger referenced by FEDGEN before running experiments so policy reviewers start with aligned evidence.',
+    href: '/about/white-papers/',
+    label: 'Access compliance brief',
+  },
+  {
+    title: 'Book a Trace Synthesis rehearsal',
+    description:
+      'Pair with our applied science team to rehearse replay flows and confirm telemetry outputs ahead of publication deadlines.',
+    href: '/about/contact/?team=research&intent=trace-synthesis',
+    label: 'Schedule rehearsal',
+  },
+  {
+    title: 'Explore Nova research tenants',
+    description:
+      'Walk through the Nova AI Research Workbench to understand isolation policies, export controls, and evidence capture.',
+    href: '/solutions/nova/',
+    label: 'Inspect Nova workbench',
+  },
+];
+---
+
+<MarketingShell title={data.title} description={heroCopy} {breadcrumbs}>
+  <SchemaScript slot="head" schema={schemaPayload} />
+
+  <MarketingHero
+    eyebrow="Research"
+    headline={data.title}
+    copy={heroCopy}
+    cta={{
+      label: data.heroCtaLabel ?? 'Request sandbox access',
+      href: heroCtaHref,
+      description: heroCtaDescription,
+    }}
+  />
+
+  <article
+    class="prose prose-invert prose-headings:font-semibold prose-headings:text-white prose-p:text-slate-200 prose-strong:text-white max-w-none"
+  >
+    <Content />
+  </article>
+
+  <MarketingCtaRow heading="Accelerate your research program" items={ctaItems} />
+</MarketingShell>

--- a/src/stories/homepage/cta-banners.stories.tsx
+++ b/src/stories/homepage/cta-banners.stories.tsx
@@ -1,5 +1,6 @@
 import DemoBannerSection from '../../components/homepage/DemoBannerSection';
 import InvestorBannerSection from '../../components/homepage/InvestorBannerSection';
+import ResearchBannerSection from '../../components/homepage/ResearchBannerSection';
 import { footerContact } from '../../components/navigation/contactMetadata';
 
 import type { Meta, Story } from '@ladle/react';
@@ -34,6 +35,17 @@ const demoBanner = {
   },
 };
 
+const researchBanner = {
+  heading: 'Research partnerships & sandboxes',
+  body: 'Coordinate academic cohorts, FEDGEN integrations, and Trace Synthesis sandboxes without bespoke intake workflows.',
+  secondaryText: `Research requests route to dedicated RevOps analysts during ${footerContact.officeHours}.`,
+  cta: {
+    label: 'Explore research hub',
+    href: '/research',
+    ariaLabel: 'Navigate to the Apotheon.ai research and academic partnerships hub',
+  },
+};
+
 export const BannerShowcase: Story = () => (
   <article className="token-story">
     <header>
@@ -46,6 +58,7 @@ export const BannerShowcase: Story = () => (
 
     <div className="space-y-10">
       <InvestorBannerSection banner={investorBanner} />
+      <ResearchBannerSection banner={researchBanner} />
       <DemoBannerSection banner={demoBanner} />
     </div>
 

--- a/src/utils/__tests__/seo.test.ts
+++ b/src/utils/__tests__/seo.test.ts
@@ -4,6 +4,7 @@ import {
   buildArticleSchema,
   buildBreadcrumbSchema,
   buildFaqSchema,
+  buildHowToSchema,
   buildOrganizationSchema,
   buildSoftwareApplicationSchema,
   buildWebsiteSchema,
@@ -186,6 +187,34 @@ describe('structured data builders', () => {
         {
           name: 'How fast is onboarding?',
         },
+      ],
+      inLanguage: 'en-US',
+    });
+  });
+
+  it('builds HowTo schema payloads', () => {
+    const schema = buildHowToSchema({
+      name: 'Provision research sandbox access',
+      description: 'Steps researchers follow before activating Nova tenants.',
+      steps: [
+        {
+          name: 'Request access',
+          text: 'Submit the sandbox form with research intent metadata.',
+          url: `${SITE_ORIGIN}/about/contact/?team=research`,
+        },
+        {
+          name: 'Validate corpora',
+          text: 'Execute npm run ensure:research-intake -- --dry-run to emit manifests.',
+        },
+      ],
+    });
+
+    expect(schema).toMatchObject({
+      '@type': 'HowTo',
+      name: 'Provision research sandbox access',
+      step: [
+        { '@type': 'HowToStep', position: 1 },
+        { '@type': 'HowToStep', position: 2 },
       ],
       inLanguage: 'en-US',
     });

--- a/src/utils/breadcrumbs.test.ts
+++ b/src/utils/breadcrumbs.test.ts
@@ -65,6 +65,11 @@ describe('breadcrumbs utilities', () => {
       { href: '/', label: 'Home', isCurrentPage: false },
       { href: '/industries/', label: 'Industries', isCurrentPage: true },
     ]);
+
+    expect(createMarketingIndexTrail('research')).toEqual([
+      { href: '/', label: 'Home', isCurrentPage: false },
+      { href: '/research/', label: 'Research', isCurrentPage: true },
+    ]);
   });
 
   it('builds blog index and detail trails that reuse collection metadata', () => {

--- a/src/utils/breadcrumbs.ts
+++ b/src/utils/breadcrumbs.ts
@@ -26,6 +26,10 @@ const SECTION_CONFIG = {
     label: 'About',
     href: '/about/',
   },
+  research: {
+    label: 'Research',
+    href: '/research/',
+  },
   blog: {
     label: 'Blog',
     href: '/blog/',

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -985,3 +985,31 @@ export function buildFaqSchema(
     })),
   };
 }
+
+export function buildHowToSchema({
+  name,
+  description,
+  steps,
+  locale = DEFAULT_LOCALE,
+}: {
+  name: string;
+  description?: string;
+  steps: Array<{ name: string; text: string; url?: string }>;
+  locale?: string;
+}): StructuredSchema {
+  const language = resolveLocaleCandidate(locale);
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name,
+    ...(description ? { description } : {}),
+    ...(language ? { inLanguage: language } : {}),
+    step: steps.map((step, index) => ({
+      '@type': 'HowToStep',
+      position: index + 1,
+      name: step.name,
+      text: step.text,
+      ...(step.url ? { url: step.url } : {}),
+    })),
+  };
+}

--- a/tests/e2e/fixtures/seed-pagefind.mjs
+++ b/tests/e2e/fixtures/seed-pagefind.mjs
@@ -11,7 +11,7 @@ await mkdir(targetDir, { recursive: true });
 
 const manifestPayload = {
   generatedAt: new Date().toISOString(),
-  routes: ['/','/es/'],
+  routes: ['/', '/es/', '/research/'],
   metadata: {
     note: 'Stub manifest seeded for Playwright tests. Replace with real Pagefind export in CI builds.',
   },


### PR DESCRIPTION
## Summary
- add a dedicated research marketing collection entry, diagram asset, and `/research/` route that emits breadcrumbs plus HowTo schema so researchers can self-serve sandbox onboarding
- surface the research program across the homepage (new CTA banner + schema), navigation, translations, Pagefind seeds, and documentation—including fresh research runbooks and calendar guidance
- extend shared SEO helpers/tests for HowTo payloads, harden the compression script’s glob resolver, and refresh automation manifests to keep whitepaper + pagefind pipelines aligned

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(fails: Vitest aborts with repeated `Unknown Error: [object Object]` before collecting tests—needs follow-up)*
- `npm run test:e2e` *(fails: `NoAdapterInstalled` because Astro build lacks adapter)*
- `npm run build` *(fails: `NoAdapterInstalled` during `astro build`)*

------
https://chatgpt.com/codex/tasks/task_e_68e14e6aa7c4832ea2671eea21151624