### PR TITLE
feat(blog): add configurable CTA panels

### DIFF
--- a/docs/content/BLOG_EDITORIAL.md
+++ b/docs/content/BLOG_EDITORIAL.md
@@ -17,6 +17,9 @@ ships with inline comments—treat this document as the narrative companion for 
   calculate manually after the draft stabilizes.
 - **Author block** – The `author` object powers the shared `<AuthorBio>` component and JSON-LD schema. Keep bios under 320
   characters and include optional social links for trust signals.
+- **Call to action** – Use the optional `cta` object to surface the next best action (whitepaper downloads, beta enrollment,
+  executive briefings). Pair every CTA with inline MDX comments describing when to rotate the links so future editors inherit
+  the guidance.
 
 ## Draft Management
 
@@ -26,6 +29,8 @@ ships with inline comments—treat this document as the narrative companion for 
   and inspect `dist/` locally. Never upload this build—CI runs `npm run build` without the flag to guarantee drafts stay private.
 - Draft placeholders should capture outline bullets and next steps. Schema validation ensures we never lose metadata fidelity,
   even when copy is still rough.
+- CTA placeholders are acceptable during outline phases; keep the inline comment updated so marketing knows whether a post
+  should drive whitepaper downloads, beta waitlists, or research briefings once the asset is live.
 
 ## Publishing Workflow
 

--- a/docs/dev/BLOG.md
+++ b/docs/dev/BLOG.md
@@ -4,7 +4,7 @@ This playbook documents how Apotheon.ai ships enterprise-ready blog content with
 
 ## Authoring workflow
 
-1. **Start from the schema** – Every article lives in `src/content/blog/` and must satisfy the collection defined in `src/content/config.ts`. Required frontmatter now includes hero imagery, OpenGraph artwork metadata, tags, and an optional `generatorRequestId` that lets the OG Worker correlate renders with editorial requests.
+1. **Start from the schema** – Every article lives in `src/content/blog/` and must satisfy the collection defined in `src/content/config.ts`. Required frontmatter now includes hero imagery, OpenGraph artwork metadata, tags, and an optional `generatorRequestId` that lets the OG Worker correlate renders with editorial requests. We also support an optional `cta` block so posts can route readers to whitepapers, beta programs, or research briefings without bespoke markup.
 2. **Capture tone + keywords inline** – Immediately after the frontmatter, add an HTML comment such as `<!-- editorial: tone="Confident" keywords="governance, ai ops" -->`. Content linting asserts that the cue exists so editors, SEO, and marketing automation stay aligned.
 3. **Reference reusable assets** – Store hero art in `public/images/blog/` and social images in `public/images/og/blog/`. Use descriptive alt text; the blog post template surfaces it in the figure caption and in JSON-LD.
 4. **Embed visuals** – Diagrams, quotes, and tables belong in the MDX body. Favor accessible representations (` ```text` diagrams, semantic tables) so we avoid adding dependencies for chart rendering.
@@ -19,7 +19,7 @@ This playbook documents how Apotheon.ai ships enterprise-ready blog content with
 
 ## Review expectations
 
-- **Metadata completeness** – Reviewers confirm hero art exists, OpenGraph payloads reference the correct assets, and estimated reading times are realistic.
+- **Metadata completeness** – Reviewers confirm hero art exists, OpenGraph payloads reference the correct assets, estimated reading times are realistic, and CTA metadata points at live assets (no `javascript:` or placeholder links).
 - **Automation hooks** – Keep `openGraph.image` and `openGraph.alt` accurate. `resolveOgImage` and the RSS/Atom feeds call `ensureOgAsset`, which renders signed Worker URLs and writes the results to `src/generated/og-assets.manifest.json`. Reviewers should confirm manifest diffs align with the post being updated.
 - **Accessibility + structure** – Verify headings form a logical outline, blockquotes include citations, and tables/diagrams remain readable without color.
 - **Testing receipts** – Pull requests should list the release gate commands in the description. CI enforces them, but local runs catch regressions earlier.

--- a/src/components/blog/CallToActionPanel.astro
+++ b/src/components/blog/CallToActionPanel.astro
@@ -1,0 +1,60 @@
+---
+import { normalizeBlogCta, type BlogCallToAction } from './call-to-action';
+
+export interface Props {
+  /**
+   * CTA metadata supplied by blog frontmatter. When undefined the component
+   * renders nothing so articles without a CTA stay compact.
+   */
+  readonly cta?: BlogCallToAction | null;
+}
+
+const cta = normalizeBlogCta(Astro.props.cta);
+
+if (!cta) {
+  return null;
+}
+---
+
+<!-- CTA panel renders sanitized metadata from frontmatter; all strings are normalized before hitting the DOM. -->
+<section
+  aria-labelledby="blog-cta-heading"
+  class="rounded-3xl border border-sky-400/40 bg-gradient-to-br from-slate-950 via-slate-900/90 to-slate-950 p-8 shadow-[0_40px_120px_-45px_rgba(56,189,248,0.45)]"
+  data-qa="blog-cta"
+>
+  {
+    cta.eyebrow && (
+      <p class="text-xs font-semibold tracking-[0.35em] text-sky-300 uppercase">{cta.eyebrow}</p>
+    )
+  }
+  <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+    <div class="flex flex-col gap-3">
+      <h2 id="blog-cta-heading" class="text-2xl font-semibold text-white">
+        {cta.title}
+      </h2>
+      {cta.description && <p class="text-base text-slate-300">{cta.description}</p>}
+    </div>
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center md:justify-end">
+      <a
+        class="inline-flex items-center justify-center rounded-full bg-sky-400 px-6 py-3 text-base font-semibold text-slate-950 transition hover:bg-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200"
+        data-qa="blog-cta-primary"
+        href={cta.primary.href}
+        rel={cta.primary.rel}
+      >
+        {cta.primary.label}
+      </a>
+      {
+        cta.secondary && (
+          <a
+            class="inline-flex items-center justify-center rounded-full border border-sky-300 px-6 py-3 text-base font-semibold text-sky-200 transition hover:border-sky-200 hover:text-sky-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200"
+            data-qa="blog-cta-secondary"
+            href={cta.secondary.href}
+            rel={cta.secondary.rel}
+          >
+            {cta.secondary.label}
+          </a>
+        )
+      }
+    </div>
+  </div>
+</section>

--- a/src/components/blog/call-to-action.ts
+++ b/src/components/blog/call-to-action.ts
@@ -1,0 +1,166 @@
+export interface BlogCtaLink {
+  /**
+   * Label surfaced to readers. Keep this concise and action oriented so we
+   * preserve button sizing across translations.
+   */
+  readonly label: string;
+  /**
+   * Destination for the CTA. Relative URLs keep traffic inside the marketing
+   * funnel while still allowing fully-qualified links for campaigns.
+   */
+  readonly href: string;
+  /**
+   * Optional rel attribute overrides for compliance hardening.
+   */
+  readonly rel?: string;
+}
+
+export interface BlogCallToAction {
+  /**
+   * Optional eyebrow text (e.g., “Download”) rendered above the heading.
+   */
+  readonly eyebrow?: string;
+  /**
+   * Core heading encouraging the next action.
+   */
+  readonly title: string;
+  /**
+   * Supporting copy clarifying value (limited to a short sentence).
+   */
+  readonly description?: string;
+  /**
+   * Primary link shown as a filled button.
+   */
+  readonly primary: BlogCtaLink;
+  /**
+   * Optional secondary link rendered as an outlined button.
+   */
+  readonly secondary?: BlogCtaLink;
+}
+
+interface NormalizedCtaLink {
+  readonly label: string;
+  readonly href: string;
+  readonly rel: string;
+}
+
+interface NormalizedBlogCta {
+  readonly eyebrow?: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly primary: NormalizedCtaLink;
+  readonly secondary?: NormalizedCtaLink;
+}
+
+const CTA_REL_FALLBACK = 'noopener noreferrer';
+
+function sanitizeText(value: string | undefined | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+    .replace(/"/gu, '&quot;')
+    .replace(/'/gu, '&#39;');
+}
+
+function normalizeLink(link: BlogCtaLink | undefined): NormalizedCtaLink | undefined {
+  if (!link) {
+    return undefined;
+  }
+
+  const label = sanitizeText(link.label);
+  const href = sanitizeText(link.href);
+  if (!label || !href) {
+    return undefined;
+  }
+
+  const normalizedHref = href.toLowerCase();
+  const blockedProtocols = ['javascript:', 'data:', 'vbscript:'];
+  if (blockedProtocols.some((protocol) => normalizedHref.startsWith(protocol))) {
+    return undefined;
+  }
+
+  const rel = sanitizeText(link.rel) ?? CTA_REL_FALLBACK;
+  return { label, href, rel };
+}
+
+function normalizeBlogCta(cta: BlogCallToAction | undefined | null): NormalizedBlogCta | null {
+  if (!cta) {
+    return null;
+  }
+
+  const primary = normalizeLink(cta.primary);
+  if (!primary) {
+    return null;
+  }
+
+  const secondary = normalizeLink(cta.secondary);
+
+  const eyebrow = sanitizeText(cta.eyebrow);
+  const title = sanitizeText(cta.title);
+  const description = sanitizeText(cta.description);
+
+  if (!title) {
+    return null;
+  }
+
+  return {
+    eyebrow,
+    title,
+    description,
+    primary,
+    secondary,
+  };
+}
+
+function buildLinkMarkup(link: NormalizedCtaLink, kind: 'primary' | 'secondary'): string {
+  const baseClass =
+    kind === 'primary'
+      ? 'inline-flex items-center justify-center rounded-full bg-sky-400 px-6 py-3 text-base font-semibold text-slate-950 transition hover:bg-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200'
+      : 'inline-flex items-center justify-center rounded-full border border-sky-300 px-6 py-3 text-base font-semibold text-sky-200 transition hover:border-sky-200 hover:text-sky-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200';
+
+  const dataAttribute = kind === 'primary' ? 'blog-cta-primary' : 'blog-cta-secondary';
+
+  return `<a class="${baseClass}" data-qa="${dataAttribute}" href="${escapeHtml(link.href)}" rel="${escapeHtml(link.rel)}">${escapeHtml(link.label)}</a>`;
+}
+
+export function renderBlogCtaMarkup(cta: BlogCallToAction | undefined | null): string | null {
+  const normalized = normalizeBlogCta(cta);
+  if (!normalized) {
+    return null;
+  }
+
+  const eyebrowMarkup = normalized.eyebrow
+    ? `<p class="text-xs font-semibold uppercase tracking-[0.35em] text-sky-300">${escapeHtml(normalized.eyebrow)}</p>`
+    : '';
+  const descriptionMarkup = normalized.description
+    ? `<p class="text-base text-slate-300">${escapeHtml(normalized.description)}</p>`
+    : '';
+  const secondaryMarkup = normalized.secondary
+    ? buildLinkMarkup(normalized.secondary, 'secondary')
+    : '';
+
+  return `\n    ${eyebrowMarkup}
+    <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+      <div class="flex flex-col gap-3">
+        <h2 id="blog-cta-heading" class="text-2xl font-semibold text-white">${escapeHtml(normalized.title)}</h2>
+        ${descriptionMarkup}
+      </div>
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center md:justify-end">
+        ${buildLinkMarkup(normalized.primary, 'primary')}
+        ${secondaryMarkup}
+      </div>
+    </div>
+  `;
+}
+
+export { normalizeBlogCta };

--- a/src/content/blog/ai-vendor-scorecards.mdx
+++ b/src/content/blog/ai-vendor-scorecards.mdx
@@ -37,9 +37,21 @@ openGraph:
   image: '/images/og/blog/ai-vendor-scorecards.svg'
   alt: 'Executive scorecard summarizing AI vendor risk across categories'
   generatorRequestId: 'pending-epic-14'
+# CTA: Final copy should align the workshop + worksheet destinations with the procurement enablement campaign.
+cta:
+  eyebrow: 'Workshop'
+  title: 'Operationalize your AI vendor diligence sprint'
+  description: 'Bring the scorecard to life with our facilitation kit and a RevOps-led working session tailored to your intake volume.'
+  primary:
+    label: 'Book a diligence workshop'
+    href: '/about/contact/?team=platform&intent=vendor-due-diligence'
+  secondary:
+    label: 'Request the scoring worksheet kit'
+    href: '/about/contact/?team=revops&intent=vendor-scorecard-kit'
 ---
 
 {/* editorial: tone="Analytical, executive-ready" keywords="AI vendor scorecard, procurement governance, board reporting" */}
+{/* editorial: cta="workshop + worksheet" update-links="Align with procurement enablement GTM" */}
 
 ## TODO before publishing
 

--- a/src/content/blog/aios-architecture.mdx
+++ b/src/content/blog/aios-architecture.mdx
@@ -22,9 +22,21 @@ openGraph:
   alt: 'AI operating system blueprint showing governance, orchestration, and delivery layers'
   generatorRequestId: 'aios-architecture-v1'
 draft: false
+# CTA: Keep the whitepaper + briefing links in sync with the architecture campaign landing page.
+cta:
+  eyebrow: 'Download'
+  title: 'Deep-dive into the AIOS reference architecture'
+  description: 'Pair the article with the diligence-ready blueprint and follow-up briefing to see implementation guardrails in action.'
+  primary:
+    label: 'Download the AIOS blueprint'
+    href: '/about/white-papers/#whitepaper-request'
+  secondary:
+    label: 'Book a platform governance briefing'
+    href: '/about/contact/?team=platform&intent=governance-briefing'
 ---
 
 {/* editorial: tone="Technical, decisive" keywords="AI operating system, architecture, control plane" */}
+{/* editorial: cta="whitepaper + governance briefing" update-links="Quarterly or when campaign URLs rotate" */}
 
 ## Platform principles
 

--- a/src/content/blog/continuous-learning.mdx
+++ b/src/content/blog/continuous-learning.mdx
@@ -21,9 +21,21 @@ openGraph:
   alt: 'Circular reinforcement learning workflow aligning telemetry, review boards, and deployment'
   generatorRequestId: 'continuous-learning-launch'
 draft: false
+# CTA: Nudge readers toward the RLHF beta funnel and the research advisory roster.
+cta:
+  eyebrow: 'Beta Access'
+  title: 'Pilot reinforcement learning with the governance toolkit pre-wired'
+  description: 'Enroll in the RLHF beta cohort and sync with our research council to instrument policy-compliant feedback loops.'
+  primary:
+    label: 'Request RLHF beta credentials'
+    href: '/about/contact/?team=research&intent=rlhf-beta'
+  secondary:
+    label: 'Schedule a telemetry design briefing'
+    href: '/about/contact/?team=platform&intent=telemetry-briefing'
 ---
 
 {/* editorial: tone="Pragmatic, operational" keywords="continuous learning, reinforcement learning, enterprise guardrails" */}
+{/* editorial: cta="beta + briefing" update-links="Align with RLHF release train" */}
 
 ## Feedback loops must be auditable
 

--- a/src/content/blog/federated-risk-mesh.mdx
+++ b/src/content/blog/federated-risk-mesh.mdx
@@ -35,11 +35,23 @@ openGraph:
   image: '/images/og/blog/federated-risk-mesh.svg'
   alt: 'Illustration of interconnected governance nodes representing a federated risk mesh'
   generatorRequestId: 'og-mesh-v1'
+# CTA: Steer governance buyers toward the mesh whitepaper and council briefings.
+cta:
+  eyebrow: 'Governance Briefing'
+  title: 'Deploy the federated risk mesh inside your AI control plane'
+  description: 'Download the reference pack and reserve a quarterly controls review with the responsible AI council.'
+  primary:
+    label: 'Download the risk mesh reference pack'
+    href: '/about/white-papers/#whitepaper-request'
+  secondary:
+    label: 'Book a responsible AI council briefing'
+    href: '/about/contact/?team=governance&intent=federated-mesh-briefing'
 ---
 
 > **Enterprise playbook:** This article ships with production-ready metadata, structured data hooks, and calls to action tested with the broader Apotheon.ai platform shell.
 
 {/* editorial: tone="Confident, advisory" keywords="federated risk mesh, responsible AI, governance automation" */}
+{/* editorial: cta="whitepaper + council briefing" update-links="Coordinate with governance campaign" */}
 
 ## Why federated risk meshes outperform centralized review boards
 

--- a/src/content/blog/healthcare-spotlight.mdx
+++ b/src/content/blog/healthcare-spotlight.mdx
@@ -21,9 +21,21 @@ openGraph:
   alt: 'Healthcare case study artwork blending patient care icons with secure AI pipelines'
   generatorRequestId: 'healthcare-spotlight-launch'
 draft: false
+# CTA: Connect readers with the regulated healthcare playbook and compliance briefings.
+cta:
+  eyebrow: 'Healthcare Blueprint'
+  title: 'Replicate the healthcare deployment with compliance automation baked in'
+  description: 'Access the regulated AI implementation playbook and sit down with our clinical governance council for a readiness review.'
+  primary:
+    label: 'Download the healthcare rollout kit'
+    href: '/about/white-papers/#whitepaper-request'
+  secondary:
+    label: 'Schedule a clinical governance briefing'
+    href: '/about/contact/?team=governance&intent=clinical-briefing'
 ---
 
 {/* editorial: tone="Empathetic, data-backed" keywords="healthcare AI, case study, compliance" */}
+{/* editorial: cta="whitepaper + clinical briefing" update-links="Coordinate with healthcare vertical lead" */}
 
 ## Situation snapshot
 

--- a/src/content/blog/integration-governance.mdx
+++ b/src/content/blog/integration-governance.mdx
@@ -21,9 +21,21 @@ openGraph:
   alt: 'Integration governance matrix connecting vendor tiers to automated policy enforcement'
   generatorRequestId: 'integration-governance-launch'
 draft: false
+# CTA: Channel readers into the integration governance accelerator program.
+cta:
+  eyebrow: 'Governance Accelerator'
+  title: 'Stand up integration guardrails with RevOps + platform support'
+  description: 'Claim the integration governance accelerator kit and meet with our RevOps architects to wire policy automation into your supply chain.'
+  primary:
+    label: 'Access the accelerator kit'
+    href: '/about/contact/?team=revops&intent=integration-accelerator'
+  secondary:
+    label: 'Schedule a vendor risk roadmap review'
+    href: '/about/contact/?team=governance&intent=vendor-risk-review'
 ---
 
 {/* editorial: tone="Structured, executive" keywords="integration governance, vendor risk, AI supply chain" */}
+{/* editorial: cta="accelerator + roadmap review" update-links="Sync with RevOps owner" */}
 
 ## Why integrations need first-class governance
 

--- a/src/content/blog/lightweight-assurance-patterns.mdx
+++ b/src/content/blog/lightweight-assurance-patterns.mdx
@@ -31,11 +31,23 @@ openGraph:
   image: '/images/og/blog/lightweight-assurance.svg'
   alt: 'Checklist graphic showing lightweight AI assurance workflows ready for automation'
   generatorRequestId: 'pending-epic-14'
+# CTA: Keep the assurance quick-start and beta signup aligned with the prompt engineering initiative.
+cta:
+  eyebrow: 'Assurance Starter'
+  title: 'Spin up lightweight assurance with templated guardrails'
+  description: 'Grab the lightweight assurance starter kit and enroll in the prompt engineering assurance beta for real-time coaching.'
+  primary:
+    label: 'Download the assurance starter kit'
+    href: '/about/contact/?team=governance&intent=assurance-starter'
+  secondary:
+    label: 'Join the assurance beta cohort'
+    href: '/about/contact/?team=research&intent=assurance-beta'
 ---
 
 > **Status:** Outline only. Editors should layer in customer anecdotes, KPI screenshots, and update the CTA once the security integrations clear architecture review.
 
 {/* editorial: tone="Supportive, practical" keywords="lightweight assurance, prompt engineering, AI safeguards" */}
+{/* editorial: cta="starter kit + beta" update-links="Coordinate with prompt engineering PM" */}
 
 - Why lightweight assurance matters
 - Intake form template

--- a/src/content/blog/welcome.mdx
+++ b/src/content/blog/welcome.mdx
@@ -21,9 +21,21 @@ openGraph:
   alt: 'Apotheon.ai blog launch artwork highlighting platform automation pillars'
   generatorRequestId: 'launch-series-og-welcome'
 draft: false
+# CTA: Introduce newcomers to the research briefing cadence and whitepaper library.
+cta:
+  eyebrow: 'Stay Aligned'
+  title: 'Subscribe for research briefings and automation playbooks'
+  description: 'Join the Insights cadence for launch notes, research briefings, and early access to our automation scripts.'
+  primary:
+    label: 'Request the research briefing series'
+    href: '/about/contact/?team=research&intent=briefing-series'
+  secondary:
+    label: 'Download the launch playbook'
+    href: '/about/white-papers/#whitepaper-request'
 ---
 
 {/* editorial: tone="Welcoming, authoritative" keywords="Apotheon.ai blog launch, enterprise AI, governance" */}
+{/* editorial: cta="briefing series + playbook" update-links="Coordinate with platform marketing" */}
 
 > “Enterprise AI only scales when every launch is auditable by default.” — Apotheon.ai Field Guide, 2024 Edition
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -92,6 +92,55 @@ const blogCollection = defineCollection({
           ),
       })
       .describe('OpenGraph artwork references keep marketing previews consistent across channels.'),
+    cta: z
+      .object({
+        eyebrow: z
+          .string()
+          .optional()
+          .describe(
+            'Optional eyebrow rendered above the CTA headline (e.g., “Download” or “Beta”).',
+          ),
+        title: z.string().min(1).describe('Primary CTA heading surfaced in the gradient panel.'),
+        description: z
+          .string()
+          .optional()
+          .describe('Short supporting copy that explains the value of the linked resource.'),
+        primary: z
+          .object({
+            label: z.string().min(1).describe('Button label for the highest priority action.'),
+            href: z
+              .string()
+              .min(1)
+              .describe('Absolute or relative URL to the target asset or workflow.'),
+            rel: z
+              .string()
+              .optional()
+              .describe(
+                'Optional rel override for the primary link when legal/compliance requires it.',
+              ),
+          })
+          .describe('Primary CTA rendered as a filled pill button.'),
+        secondary: z
+          .object({
+            label: z
+              .string()
+              .min(1)
+              .describe('Secondary button label for readers who need a softer touchpoint.'),
+            href: z
+              .string()
+              .min(1)
+              .describe('Absolute or relative URL for the secondary follow-up action.'),
+            rel: z.string().optional().describe('Optional rel override for the secondary link.'),
+          })
+          .optional()
+          .describe(
+            'Optional secondary CTA shown as an outlined pill for comparison shopping journeys.',
+          ),
+      })
+      .optional()
+      .describe(
+        'Optional CTA metadata appended to the article. When omitted, the layout suppresses the gradient panel automatically.',
+      ),
     draft: z
       .boolean()
       .default(false)

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 
 import AuthorBio from '../../components/blog/AuthorBio.astro';
+import CallToActionPanel from '../../components/blog/CallToActionPanel.astro';
 import RelatedPosts from '../../components/blog/RelatedPosts.astro';
 import Breadcrumbs from '../../components/navigation/Breadcrumbs.astro';
 import SchemaScript from '../../components/seo/SchemaScript.astro';
@@ -120,6 +121,9 @@ const breadcrumbSchema = buildBreadcrumbSchema(breadcrumbs, siteOrigin, pageLoca
     <section class="prose prose-invert prose-slate max-w-none">
       <Content />
     </section>
+
+    <!-- CTA metadata lives in `cta` frontmatter so marketing can rotate assets without touching markup. -->
+    <CallToActionPanel cta={entry.data.cta} />
 
     {
       headings.length > 3 && (

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -6,6 +6,7 @@ export type BlogCollectionEntry = CollectionEntry<'blog'>;
 export type BlogEntryData = InferEntrySchema<'blog'>;
 export type BlogAuthorMetadata = BlogEntryData['author'];
 export type BlogOpenGraphMetadata = BlogEntryData['openGraph'];
+export type BlogEntryCallToAction = BlogEntryData['cta'];
 
 /**
  * Supported publish date sorting directions.

--- a/tests/e2e/blog-posts.spec.ts
+++ b/tests/e2e/blog-posts.spec.ts
@@ -46,4 +46,20 @@ test.describe('blog posts', () => {
     expect(atomText).toContain('<feed');
     expect(atomText).toContain('<entry>');
   });
+
+  test('published posts render CTA panels with routable links', async ({ page }) => {
+    await page.goto('/blog/aios-architecture/');
+    const cta = page.locator('[data-qa="blog-cta"]');
+    await expect(cta).toBeVisible();
+
+    const primary = cta.locator('[data-qa="blog-cta-primary"]');
+    await expect(primary).toHaveAttribute('href', '/about/white-papers/#whitepaper-request');
+
+    const primaryHref = await primary.getAttribute('href');
+    expect(primaryHref).toBeTruthy();
+
+    const resolvedUrl = new URL(primaryHref ?? '', page.url()).toString();
+    const response = await page.request.get(resolvedUrl);
+    expect(response.ok()).toBeTruthy();
+  });
 });

--- a/tests/unit/blog-call-to-action.spec.ts
+++ b/tests/unit/blog-call-to-action.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderBlogCtaMarkup } from '../../src/components/blog/call-to-action';
+
+describe('renderBlogCtaMarkup', () => {
+  it('returns hydrated markup for valid CTA metadata', () => {
+    const markup = renderBlogCtaMarkup({
+      eyebrow: 'Download',
+      title: 'Review the AIOS blueprint',
+      description: 'Pair the article with our diligence-ready playbook.',
+      primary: {
+        label: 'Download now',
+        href: '/about/white-papers/#whitepaper-request',
+      },
+      secondary: {
+        label: 'Book a briefing',
+        href: '/about/contact/?team=platform&intent=architecture-briefing',
+      },
+    });
+
+    expect(markup).toBeTruthy();
+
+    const container = document.createElement('section');
+    container.innerHTML = markup ?? '';
+    const heading = container.querySelector('#blog-cta-heading');
+    const primary = container.querySelector('[data-qa="blog-cta-primary"]');
+    const secondary = container.querySelector('[data-qa="blog-cta-secondary"]');
+
+    expect(heading?.textContent).toContain('Review the AIOS blueprint');
+    expect(primary?.getAttribute('href')).toBe('/about/white-papers/#whitepaper-request');
+    expect(secondary?.getAttribute('href')).toBe(
+      '/about/contact/?team=platform&intent=architecture-briefing',
+    );
+  });
+
+  it('returns null when the CTA metadata is incomplete', () => {
+    const markup = renderBlogCtaMarkup({
+      title: 'Missing link example',
+      primary: {
+        label: 'Fix me',
+        href: '   ',
+      },
+    });
+
+    expect(markup).toBeNull();
+  });
+
+  it('omits optional metadata when secondary links are absent', () => {
+    const markup = renderBlogCtaMarkup({
+      title: 'Single link CTA',
+      primary: {
+        label: 'Download now',
+        href: '/about/white-papers/#whitepaper-request',
+      },
+    });
+
+    expect(markup).toBeTruthy();
+
+    const container = document.createElement('section');
+    container.innerHTML = markup ?? '';
+
+    expect(container.querySelector('[data-qa="blog-cta-secondary"]')).toBeNull();
+    expect(container.querySelector('[data-qa="blog-cta-primary"]')).not.toBeNull();
+  });
+
+  it('escapes HTML entities to prevent injection', () => {
+    const markup = renderBlogCtaMarkup({
+      eyebrow: '<script>alert(1)</script>',
+      title: '<script>alert(2)</script>',
+      description: '<img src=x onerror=alert(3)>',
+      primary: {
+        label: 'Click <me>',
+        href: 'https://example.com/path?<script>',
+      },
+    });
+
+    expect(markup).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(markup).toContain('&lt;script&gt;alert(2)&lt;/script&gt;');
+    expect(markup).toContain('&lt;img src=x onerror=alert(3)&gt;');
+    expect(markup).toContain('href=&quot;https://example.com/path?&lt;script&gt;&quot;');
+  });
+
+  it('rejects blocked URL protocols to avoid JavaScript execution', () => {
+    const markup = renderBlogCtaMarkup({
+      title: 'Protocol safety',
+      primary: {
+        label: 'Do not render',
+        href: 'javascript:alert(1)',
+      },
+    });
+
+    expect(markup).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable blog CTA panel component and schema helpers
- populate CTA metadata in each blog post and document editorial guidance
- extend e2e and unit test coverage for CTA behaviour

## Testing
- npm run lint
- npm run typecheck
- npm run test *(fails: vitest reports unhandled errors prior to executing suites)*
- npm run test:e2e *(fails: astro build pre-step requires an adapter for server routes)*
- npm run build *(fails: astro build requires a server adapter in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e172cdc00c832ea065694da827e07c